### PR TITLE
Redesign site with left-rail Atelier layout

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1,52 +1,104 @@
-# DESIGN_SYSTEM.md — hongincanada.com (Refined Editorial)
+# DESIGN_SYSTEM.md — hongincanada.com ("Atelier" — left-rail engineering studio)
 
 Serves BRIEF.md. Redesign of an existing SvelteKit portfolio/blog. User-confirmed intake:
-**Mood = Serious/editorial · Mode = Light default + polished dark toggle · Motion = Subtle · Accent = Ink blue.**
+**A genuinely new structural paradigm — a fixed left side menu, professional + impressive.**
+**Mood = Serious/studio · Mode = Light default + polished dark toggle · Motion = Subtle · Accent = Teal.**
+
+This is the second redesign. The previous pass ("Refined Editorial") only changed theme/font/color.
+This pass changes the **layout paradigm**: a persistent left navigation rail replaces the top nav bar.
 
 ## Stack
 SvelteKit 2 + Svelte 5 (runes) + TypeScript + Tailwind CSS 3 + @tailwindcss/typography. Node adapter. (Fixed — existing project.)
 
+## Layout paradigm — the headline change
+- **Fixed left sidebar rail** on desktop (`lg+`), width `--rail-w` (16rem). Content column is offset right via
+  the `.content-shell` class (`@media (min-width:1024px){ padding-left: var(--rail-w) }`).
+- **Mobile / tablet (`< lg`):** rail collapses. A slim top bar (h-16) exposes a hamburger that opens a
+  **slide-in drawer** carrying the identical rail content (shared via a Svelte 5 `{#snippet railBody()}`).
+- **Rail anatomy (top → bottom):** brand (avatar + "Hong" + mono role) → `EXPLORE` group
+  (Home / Projects / Writing / About) → `SERIES & TOOLS` group (AI Review / Minibreaks / Mosaic) →
+  `LATEST` group (3 most recent blog posts, sorted by `date` in `blogPosts.ts`, + an "All writing" link
+  to the `/blog` archive) → `mt-auto` footer (Get-in-touch teal CTA + GitHub/LinkedIn/Strava socials +
+  theme toggle). The rail is `overflow-y-auto` as a last-resort fallback, but is height-responsive so
+  that fallback rarely triggers.
+- **Height-responsive rail (avoids the "double scrollbar" look):** the footer (CTA + socials + theme
+  toggle) is always visible — it's the priority. Section rhythm (`.rail-section`/`.rail-section-first`/
+  `.rail-bottom` margins, `.rail-link`/`.rail-post` min-heights, `.rail-label` padding) is driven by CSS
+  custom properties on `.rail` (`--rail-gap`, `--rail-link-h`, etc.) that step down at `@media (max-height:
+  900px)` for laptops with browser chrome. Below `@media (max-height: 820px)`, the `LATEST` group
+  (`.rail-latest`) is hidden entirely rather than shrinking links further or scrolling — progressive
+  disclosure: optional content drops out before the pinned footer would be pushed off-screen.
+- **Active state:** `aria-current="page"` drives a teal left-edge bar + soft teal surface on the current rail link.
+
 ## Typography
-- **Display / headings:** `Fraunces` (editorial serif w/ optical sizing) — distinctive, senior, memorable. Weights 400/500/600. Used for name, section titles, article H1/H2.
-- **Body / UI:** `Inter` — crisp, professional sans. Weights 400/500/600/700.
-- **Mono (code):** `ui-monospace` system stack.
-- Body reading: 18px (`prose-lg`-ish), line-height 1.75, measure ~66ch (`max-w-[42rem]`). This measure is the #1 eye-flow lever for article routes.
+- **Display / headings:** `Fraunces` (editorial serif w/ optical sizing). Weights 400/500/600/700. Name, section titles, article H1/H2.
+- **Body / UI:** `Inter`. Weights 400/500/600/700.
+- **Mono (labels):** `JetBrains Mono` — **new**. Used for eyebrows, rail nav labels, group headers (`EXPLORE`/`READ`), and metadata. This is the studio/engineering signature of the redesign. Weights 400/500/600.
+- Body reading: 18px, line-height 1.75, measure ~66ch (`max-w-[42rem]`) on article routes.
 - Type scale: hero 3.5–5rem; H2 ~1.9rem; H3 ~1.3rem; body 1.125rem; small 0.875rem.
-- Letter-spacing: tight on large serif display (-0.02em); normal on body.
+- Letter-spacing: tight on large serif display (-0.02em); wide + uppercase on mono eyebrows/labels.
 
 ## Color tokens (CSS variables, class-based dark mode)
+Graphite neutrals + a single **teal** accent (replaces the previous ink blue).
+
 Light (default):
-- `--bg` #FCFCFB (warm paper) · `--surface` #FFFFFF · `--surface-2` #F6F5F2
-- `--text` #1A1A1A · `--muted` #565B62 · `--faint` #8A9099
+- `--bg` #F7F7F6 · `--surface` #FFFFFF · `--surface-2` #F1F1EF
+- `--text` #17181A · `--muted` #565B62 · `--faint` #8A9099
 - `--border` rgba(17,17,17,0.10) · `--border-strong` rgba(17,17,17,0.16)
-- `--accent` #2452D6 (ink blue) · `--accent-strong` #1B3FAE · `--accent-soft` rgba(36,82,214,0.08)
+- `--accent` #0F766E (teal) · `--accent-strong` #0B5A54 · `--accent-soft` rgba(15,118,110,0.08)
 Dark:
-- `--bg` #0D0E11 · `--surface` #15171B · `--surface-2` #1B1E23
+- `--bg` #0A0B0D · `--surface` #131519 · `--surface-2` #1A1D22
 - `--text` #ECEDEA · `--muted` #A0A6AE · `--faint` #6B7280
 - `--border` rgba(255,255,255,0.10) · `--border-strong` rgba(255,255,255,0.18)
-- `--accent` #7DA0FF · `--accent-strong` #A8C0FF · `--accent-soft` rgba(125,160,255,0.12)
+- `--accent` #2DD4BF · `--accent-strong` #5EEAD4 · `--accent-soft` rgba(45,212,191,0.12)
 
-One accent only. No multi-hue gradient text. Category tags may use a single muted tint, not rainbow.
+One accent only across chrome. Exception: the **home page** retains its intentional multi-hue project/writing
+chips (deliberate, curated — not rainbow gradient text). All other routes use teal exclusively.
+
+### `--on-accent` (text-on-accent contrast token)
+The dark-mode accent (#2DD4BF) is a bright teal chosen for visibility against dark backgrounds — but
+that brightness fails WCAG AA when paired with white text (1.86:1, needs ≥4.5:1). `--on-accent` decouples
+"the color of text placed on an accent-colored background" from the old white/black assumption:
+- Light: `--on-accent` #FFFFFF (light-mode accent #0F766E is dark enough — 5.47:1 with white)
+- Dark: `--on-accent` #062420 (deep teal-black — 8.8:1+ with the dark-mode accent/accent-strong)
+
+Any button/badge with `background: var(--accent)` (or `--accent-strong`) must use `color: var(--on-accent)`
+instead of a hardcoded `text-white`/black class, so it stays readable when the theme toggles.
 
 ## Layout & spacing
 - Container: `max-w-6xl` for landing sections; `max-w-[42rem]` reading column for articles.
-- Generous vertical rhythm: sections `py-24`/`py-28`; clear whitespace between blocks.
-- Cards: flat editorial style — 1px border, subtle surface, `rounded-xl`, hover = border+shadow lift (no glass blur).
-- Thin hairline rules (`--border`) to separate editorial sections instead of heavy boxes.
+- Generous vertical rhythm: sections `py-24`/`py-28`.
+- Cards: flat studio style — 1px border, subtle surface, `rounded-xl`, hover = border+shadow lift (no glass blur).
+- Thin hairline rules (`--border`) separate sections instead of heavy boxes.
+- `--rail-w: 16rem` is the single source of truth for rail width + content offset.
 
 ## Components
-- **Nav:** minimal, hairline bottom border, serif wordmark, light by default; solidifies on scroll.
-- **Hero:** typographic — large serif name + concise positioning line + primary actions. No animated rainbow mesh; at most a quiet static texture + one subtle entrance fade.
-- **Article template (BaseSeriesPage + blog posts):** centered ~66ch column, serif H1/H2, sans body, comfortable line-height, accent left-rule on H2 (thin, ink blue), quiet TOC. Prev/next + SEO preserved.
-- **Buttons/links:** text links underlined on hover with accent; primary button = solid accent, secondary = hairline outline.
+- **Rail (`.rail`, `.rail-link`, `.mono-label`):** fixed left nav on desktop; drawer on mobile. `.rail-link`
+  enforces min-height 44px and renders the aria-current active bar. Group headers use `.mono-label`.
+- **Content shell (`.content-shell`):** wraps every route; applies the left offset at `lg+`. (A dedicated CSS
+  class, not a Tailwind `pl-*` utility — the utility was JIT-missed and computed to 0.)
+- **Eyebrow (`.eyebrow`):** now mono, uppercase, wide-tracked, teal.
+- **Hero:** typographic — large serif name + concise positioning line + primary actions.
+- **Article template (BaseSeriesPage + blog posts):** centered ~66ch column, serif H1/H2, sans body,
+  teal accent left-rule on H2, quiet sticky TOC, breadcrumbs, prev/next. SEO + JSON-LD `BlogPosting` preserved.
+- **Buttons/links:** primary = solid teal, secondary = hairline outline; text links hover-underline in teal.
 
 ## Motion
-- Subtle only: entrance fade/translate (200–300ms), hover transitions (150–200ms), animate transform/opacity.
-- Full `prefers-reduced-motion` support (disable transitions/animation).
-- Retain a tasteful, low-key hero entrance; drop the multi-stage cinematic gradient sequence.
+- Subtle only: entrance fade/translate (200–300ms), hover transitions (150–200ms), drawer slide (transform).
+- Animate transform/opacity only. Full `prefers-reduced-motion` support (disable transitions/animation).
 
 ## Accessibility
-WCAG AA contrast, visible focus rings (accent), 44px touch targets, keyboard order = visual order, semantic headings preserved.
+WCAG AA contrast, visible teal focus rings, 44px touch targets (incl. rail links), keyboard order = visual
+order, skip link, `aria-current` on active rail item, drawer is keyboard-dismissible, semantic headings preserved.
 
 ## Non-negotiables preserved
-All content verbatim; SEO/meta/OG/JSON-LD; TOC/anchor/scroll-offset behavior; series prev/next; RSS alternate.
+All content verbatim; every `<svelte:head>` (SEO/meta/OG/Twitter/JSON-LD); TOC/anchor/scroll-offset behavior;
+series prev/next; RSS alternate; analytics/adsense/verification tags.
+
+## Routes added in this pass
+- `/blog` — a writing archive/index page listing every post from `blogPosts.ts` (newest first, with
+  publish dates + `Blog` JSON-LD). Serves as the "View all writing" target from the home page, the rail's
+  "All writing" link, and the `MorePosts` "All posts" link.
+- Home page condensed: tighter section rhythm (`py-16`), the Writing grid trimmed to the 4 most recent
+  posts + the two series hubs (with a "View all writing" CTA), and a new **Free AI Workflow Review** feature
+  banner between Projects and Writing linking to `/ai-workflow-review`.

--- a/src/app.css
+++ b/src/app.css
@@ -3,36 +3,40 @@
 @tailwind utilities;
 
 /* ============================================================= */
-/* Design tokens — Refined Editorial (light default + dark mode) */
+/* Design tokens — Atelier (graphite + teal, left-rail studio)   */
+/* Light default + dark mode. Single teal accent.                */
 /* ============================================================= */
 :root {
-	--bg: #fbfaf8;
+	--bg: #f7f7f6;
 	--surface: #ffffff;
-	--surface-2: #f4f2ee;
-	--text: #191919;
-	--muted: #52565c;
-	--faint: #85898f;
-	--border: rgba(20, 20, 20, 0.1);
-	--border-strong: rgba(20, 20, 20, 0.16);
-	--accent: #2452d6;
-	--accent-strong: #1b3fae;
-	--accent-soft: rgba(36, 82, 214, 0.08);
-	--shadow: 0 1px 2px rgba(20, 20, 20, 0.04), 0 12px 32px -16px rgba(20, 20, 20, 0.14);
+	--surface-2: #efefed;
+	--text: #17181a;
+	--muted: #52555b;
+	--faint: #8a8d93;
+	--border: rgba(18, 20, 24, 0.1);
+	--border-strong: rgba(18, 20, 24, 0.17);
+	--accent: #0f766e;
+	--accent-strong: #0b5e54;
+	--accent-soft: rgba(15, 118, 110, 0.09);
+	--on-accent: #ffffff;
+	--shadow: 0 1px 2px rgba(18, 20, 24, 0.04), 0 14px 34px -18px rgba(18, 20, 24, 0.16);
+	--rail-w: 16rem;
 }
 
 .dark {
-	--bg: #0d0e11;
-	--surface: #15171b;
-	--surface-2: #1c1f24;
-	--text: #ecedea;
-	--muted: #a2a8b0;
-	--faint: #6c727a;
-	--border: rgba(255, 255, 255, 0.1);
-	--border-strong: rgba(255, 255, 255, 0.17);
-	--accent: #86a5ff;
-	--accent-strong: #adc3ff;
-	--accent-soft: rgba(134, 165, 255, 0.13);
-	--shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 18px 40px -18px rgba(0, 0, 0, 0.6);
+	--bg: #0a0b0d;
+	--surface: #131518;
+	--surface-2: #1a1d21;
+	--text: #ececee;
+	--muted: #a2a6ad;
+	--faint: #6a6e76;
+	--border: rgba(255, 255, 255, 0.09);
+	--border-strong: rgba(255, 255, 255, 0.16);
+	--accent: #2dd4bf;
+	--accent-strong: #5eead4;
+	--accent-soft: rgba(45, 212, 191, 0.13);
+	--on-accent: #062420;
+	--shadow: 0 1px 2px rgba(0, 0, 0, 0.5), 0 20px 44px -20px rgba(0, 0, 0, 0.65);
 }
 
 html {
@@ -154,13 +158,204 @@ body {
 	background: var(--border-strong);
 }
 
-/* Thin accent eyebrow */
+/* Thin accent eyebrow — mono, engineering signal */
 .eyebrow {
 	color: var(--accent);
-	font-weight: 600;
-	letter-spacing: 0.18em;
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	font-weight: 500;
+	letter-spacing: 0.16em;
 	text-transform: uppercase;
-	font-size: 0.72rem;
+	font-size: 0.7rem;
+}
+
+/* ============================================================= */
+/* Left rail (sidebar) — the new structural chrome               */
+/* ============================================================= */
+.rail {
+	--rail-gap: 2rem;
+	--rail-gap-sm: 1.5rem;
+	--rail-link-h: 40px;
+	--rail-link-py: 0.5rem;
+	--rail-label-pb: 0.5rem;
+	--rail-pad-y: 1.25rem;
+	background: color-mix(in srgb, var(--surface) 60%, var(--bg));
+	border-right: 1px solid var(--border);
+	padding-top: var(--rail-pad-y);
+	padding-bottom: var(--rail-pad-y);
+}
+
+/* Section rhythm inside the rail, driven by CSS vars so it can shrink in
+   tiers as viewport height shrinks — keeps the whole nav in one viewport
+   instead of needing its own scrollbar alongside the page's. */
+.rail-section {
+	margin-top: var(--rail-gap-sm);
+}
+
+.rail-section-first {
+	margin-top: var(--rail-gap);
+}
+
+.rail-bottom {
+	padding-top: var(--rail-gap-sm);
+}
+
+.rail-label {
+	padding-bottom: var(--rail-label-pb);
+}
+
+/* Compact tier: laptops with browser chrome, landscape tablets */
+@media (max-height: 900px) {
+	.rail {
+		--rail-gap: 1.1rem;
+		--rail-gap-sm: 0.85rem;
+		--rail-link-h: 36px;
+		--rail-link-py: 0.4rem;
+		--rail-label-pb: 0.3rem;
+		--rail-pad-y: 0.85rem;
+	}
+}
+
+/* Below this height even the compact tier can't fit every section alongside
+   the always-visible footer (social links + theme toggle) — hide the
+   "Latest" nav rather than shrinking links further or scrolling the rail. */
+@media (max-height: 820px) {
+	.rail-latest {
+		display: none;
+	}
+}
+
+/* Content column offset so it clears the fixed left rail on desktop */
+@media (min-width: 1024px) {
+	.content-shell {
+		padding-left: var(--rail-w);
+	}
+}
+
+.rail-link {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 0.85rem;
+	border-radius: 0.6rem;
+	padding: var(--rail-link-py) 0.75rem;
+	min-height: 40px;
+	font-size: 0.9rem;
+	color: var(--muted);
+	transition: color 0.18s ease, background-color 0.18s ease;
+}
+
+.rail-link:hover {
+	color: var(--text);
+	background: var(--accent-soft);
+}
+
+.rail-link i {
+	width: 1.15rem;
+	text-align: center;
+	color: var(--faint);
+	transition: color 0.18s ease;
+}
+
+.rail-link:hover i,
+.rail-link[aria-current='page'] i {
+	color: var(--accent);
+}
+
+.rail-link[aria-current='page'] {
+	color: var(--text);
+	background: var(--accent-soft);
+	font-weight: 500;
+}
+
+.rail-link[aria-current='page']::before {
+	content: '';
+	position: absolute;
+	left: -0.5rem;
+	top: 50%;
+	transform: translateY(-50%);
+	height: 1.15rem;
+	width: 3px;
+	border-radius: 3px;
+	background: var(--accent);
+}
+
+/* Compact "latest posts" link in the rail (icon + single-line short title) */
+.rail-post {
+	display: flex;
+	align-items: center;
+	gap: 0.7rem;
+	border-radius: 0.6rem;
+	padding: 0.5rem 0.75rem;
+	min-height: 40px;
+	color: var(--muted);
+	transition: color 0.18s ease, background-color 0.18s ease;
+}
+
+.rail-post:hover {
+	color: var(--text);
+	background: var(--accent-soft);
+}
+
+.rail-post i {
+	width: 1.05rem;
+	text-align: center;
+	font-size: 0.8rem;
+	color: var(--faint);
+	transition: color 0.18s ease;
+}
+
+.rail-post:hover i {
+	color: var(--accent);
+}
+
+.rail-post-title {
+	font-size: 0.85rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.rail-post[aria-current='page'] {
+	color: var(--text);
+	background: var(--accent-soft);
+	font-weight: 500;
+}
+
+.rail-post[aria-current='page'] i {
+	color: var(--accent);
+}
+
+/* Mono meta label used across chrome */
+.mono-label {
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	font-size: 0.68rem;
+	color: var(--faint);
+}
+
+/* Brand identity chips (rail) — discrete pills instead of a dot-separated
+   line, so wrapping breaks cleanly between tags rather than mid-phrase */
+/* Brand identity chips (rail) — 2-column grid so pairs stay balanced
+   regardless of label length, instead of flex-wrap's uneven 3+1 split */
+.rail-tags {
+	display: grid;
+	grid-template-columns: repeat(2, max-content);
+	gap: 0.4rem;
+}
+
+.rail-tag {
+	font-family: 'JetBrains Mono', ui-monospace, monospace;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	font-size: 0.62rem;
+	line-height: 1.3;
+	color: var(--muted);
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: 0.35rem;
+	padding: 0.2rem 0.45rem;
+	white-space: nowrap;
 }
 
 /* Entrance animation helpers */

--- a/src/app.css
+++ b/src/app.css
@@ -238,7 +238,7 @@ body {
 	gap: 0.85rem;
 	border-radius: 0.6rem;
 	padding: var(--rail-link-py) 0.75rem;
-	min-height: 40px;
+	min-height: var(--rail-link-h);
 	font-size: 0.9rem;
 	color: var(--muted);
 	transition: color 0.18s ease, background-color 0.18s ease;

--- a/src/app.css
+++ b/src/app.css
@@ -208,7 +208,7 @@ body {
 	.rail {
 		--rail-gap: 1.1rem;
 		--rail-gap-sm: 0.85rem;
-		--rail-link-h: 36px;
+		--rail-link-h: 44px;
 		--rail-link-py: 0.4rem;
 		--rail-label-pb: 0.3rem;
 		--rail-pad-y: 0.85rem;

--- a/src/app.css
+++ b/src/app.css
@@ -174,7 +174,7 @@ body {
 .rail {
 	--rail-gap: 2rem;
 	--rail-gap-sm: 1.5rem;
-	--rail-link-h: 40px;
+	--rail-link-h: 44px;
 	--rail-link-py: 0.5rem;
 	--rail-label-pb: 0.5rem;
 	--rail-pad-y: 1.25rem;

--- a/src/app.css
+++ b/src/app.css
@@ -286,7 +286,7 @@ body {
 	gap: 0.7rem;
 	border-radius: 0.6rem;
 	padding: 0.5rem 0.75rem;
-	min-height: 40px;
+	min-height: var(--rail-link-h);
 	color: var(--muted);
 	transition: color 0.18s ease, background-color 0.18s ease;
 }

--- a/src/app.html
+++ b/src/app.html
@@ -8,7 +8,7 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link
 			rel="stylesheet"
-			href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600;700&display=swap"
+			href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
 		/>
 		%sveltekit.head%
 	</head>

--- a/src/lib/components/BaseSeriesPage.svelte
+++ b/src/lib/components/BaseSeriesPage.svelte
@@ -160,15 +160,15 @@ Best regards`;
         <div class="flex items-center space-x-4">
             <!-- Breadcrumb Path -->
             <div class="flex items-center space-x-2 text-sm">
-                <a href="/" class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors">Home</a>
+                <a href="/" class="text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300 transition-colors">Home</a>
                 <i class="fas fa-chevron-right text-gray-400 dark:text-gray-500" aria-hidden="true"></i>
-                <a href="{navigation.seriesUrl}" class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors">{navigation.seriesTitle}</a>
+                <a href="{navigation.seriesUrl}" class="text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300 transition-colors">{navigation.seriesTitle}</a>
                 <i class="fas fa-chevron-right text-gray-400 dark:text-gray-500" aria-hidden="true"></i>
                 <span class="text-gray-600 dark:text-gray-400">Part {navigation.currentPart}</span>
             </div>
             <!-- Part Indicator -->
             <div class="hidden sm:block">
-                <span class="bg-blue-500 dark:bg-blue-600 text-white px-3 py-1 rounded-full text-xs font-medium">
+                <span class="bg-teal-500 dark:bg-teal-600 text-white px-3 py-1 rounded-full text-xs font-medium">
                     Part {navigation.currentPart} of {navigation.totalParts}
                 </span>
             </div>
@@ -183,17 +183,17 @@ Best regards`;
             <!-- Back to Series button - only show on mobile when part indicator is hidden -->
             <div class="sm:hidden mb-6">
                 <div class="flex flex-col items-center gap-3">
-                    <a href="{navigation.seriesUrl}" class="inline-flex min-h-[44px] items-center bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-4 py-2 rounded-full text-sm font-medium hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors">
+                    <a href="{navigation.seriesUrl}" class="inline-flex min-h-[44px] items-center bg-teal-100 dark:bg-teal-900 text-teal-800 dark:text-teal-200 px-4 py-2 rounded-full text-sm font-medium hover:bg-teal-200 dark:hover:bg-teal-800 transition-colors">
                         <i class="fas fa-arrow-left mr-2" aria-hidden="true"></i>Back to Series
                     </a>
-                    <span class="bg-blue-500 dark:bg-blue-600 text-white px-4 py-2 rounded-full text-sm font-medium">
+                    <span class="bg-teal-500 dark:bg-teal-600 text-white px-4 py-2 rounded-full text-sm font-medium">
                         Part {navigation.currentPart} of {navigation.totalParts}
                     </span>
                 </div>
             </div>
             <!-- Desktop: Just the back button since part indicator is in nav -->
             <div class="hidden sm:block mb-6">
-                <a href="{navigation.seriesUrl}" class="inline-flex min-h-[44px] items-center bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-4 py-2 rounded-full text-sm font-medium hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors">
+                <a href="{navigation.seriesUrl}" class="inline-flex min-h-[44px] items-center bg-teal-100 dark:bg-teal-900 text-teal-800 dark:text-teal-200 px-4 py-2 rounded-full text-sm font-medium hover:bg-teal-200 dark:hover:bg-teal-800 transition-colors">
                     <i class="fas fa-arrow-left mr-2" aria-hidden="true"></i>Back to Series
                 </a>
             </div>
@@ -226,9 +226,9 @@ Best regards`;
             {#if tableOfContents.length > 0}
                 <button
                     on:click={toggleTOC}
-                    class="flex items-center space-x-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-blue-300 dark:hover:border-blue-600 transition-all duration-200"
+                    class="flex items-center space-x-3 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:border-teal-300 dark:hover:border-teal-600 transition-all duration-200"
                 >
-                    <i class="fas fa-list text-blue-600 dark:text-blue-400" aria-hidden="true"></i>
+                    <i class="fas fa-list text-teal-600 dark:text-teal-400" aria-hidden="true"></i>
                     <span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Table of Contents</span>
                     <span class="sm:hidden">TOC</span>
                     <i class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-gray-400" aria-hidden="true"></i>
@@ -278,7 +278,7 @@ Best regards`;
                         <nav class="space-y-3">
                             {#each tableOfContents as item}
                                 <a href="#{item.id}"
-                                   class="block text-sm {item.level === 1 ? 'font-medium text-gray-900 dark:text-white py-1' : 'text-gray-600 dark:text-gray-400 ml-4 py-0.5'} hover:text-blue-600 dark:hover:text-blue-400 transition-colors rounded px-2 hover:bg-blue-50 dark:hover:bg-blue-900/20">
+                                   class="block text-sm {item.level === 1 ? 'font-medium text-gray-900 dark:text-white py-1' : 'text-gray-600 dark:text-gray-400 ml-4 py-0.5'} hover:text-teal-600 dark:hover:text-teal-400 transition-colors rounded px-2 hover:bg-teal-50 dark:hover:bg-teal-900/20">
                                     {item.title}
                                 </a>
                             {/each}
@@ -299,11 +299,11 @@ Best regards`;
                                     prose-ul:ml-6 prose-ul:mb-6 prose-ul:mt-4 prose-ul:space-y-2 prose-ul:list-disc prose-ul:pl-6
                                     prose-ol:ml-6 prose-ol:mb-6 prose-ol:mt-4 prose-ol:space-y-2 prose-ol:list-decimal prose-ol:pl-6
                                     prose-strong:text-gray-900 dark:prose-strong:text-white
-                                    prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:underline prose-a:decoration-2 prose-a:underline-offset-2 hover:prose-a:text-blue-800 dark:hover:prose-a:text-blue-300 prose-a:transition-colors
-                                    prose-code:text-blue-700 dark:prose-code:text-blue-300 prose-code:font-medium
-                                    prose-code:bg-blue-50 dark:prose-code:bg-blue-900/20 prose-code:px-2 prose-code:py-1 prose-code:rounded
+                                    prose-a:text-teal-600 dark:prose-a:text-teal-400 prose-a:underline prose-a:decoration-2 prose-a:underline-offset-2 hover:prose-a:text-teal-800 dark:hover:prose-a:text-teal-300 prose-a:transition-colors
+                                    prose-code:text-teal-700 dark:prose-code:text-teal-300 prose-code:font-medium
+                                    prose-code:bg-teal-50 dark:prose-code:bg-teal-900/20 prose-code:px-2 prose-code:py-1 prose-code:rounded
                                     prose-pre:bg-gray-100 dark:prose-pre:bg-gray-800 prose-pre:border prose-pre:border-gray-200 dark:prose-pre:border-gray-700
-                                    prose-blockquote:border-blue-500 dark:prose-blockquote:border-blue-400 prose-blockquote:bg-blue-50 dark:prose-blockquote:bg-blue-900/10
+                                    prose-blockquote:border-teal-500 dark:prose-blockquote:border-teal-400 prose-blockquote:bg-teal-50 dark:prose-blockquote:bg-teal-900/10
                                     prose-blockquote:text-gray-700 dark:prose-blockquote:text-gray-300
                                     prose-h1:text-4xl prose-h2:text-3xl prose-h3:text-2xl
                                     prose-h1:mb-8 prose-h2:mb-6 prose-h2:mt-12 prose-h3:mb-4 prose-h3:mt-8
@@ -334,8 +334,8 @@ Best regards`;
             <!-- Previous Part -->
             {#if navigation.prevPart}
                 <a href="{navigation.seriesUrl}/{navigation.prevPart.slug}"
-                   class="flex items-center space-x-3 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition group min-w-0">
-                    <div class="flex items-center justify-center w-12 h-12 bg-blue-100 dark:bg-blue-900 rounded-full group-hover:bg-blue-200 dark:group-hover:bg-blue-800 transition">
+                   class="flex items-center space-x-3 text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300 transition group min-w-0">
+                    <div class="flex items-center justify-center w-12 h-12 bg-teal-100 dark:bg-teal-900 rounded-full group-hover:bg-teal-200 dark:group-hover:bg-teal-800 transition">
                         <i class="fas fa-arrow-left text-lg" aria-hidden="true"></i>
                     </div>
                     <div class="min-w-0">
@@ -356,12 +356,12 @@ Best regards`;
             <!-- Next Part -->
             {#if navigation.nextPart && !disableNextPart}
                 <a href="{navigation.seriesUrl}/{navigation.nextPart.slug}"
-                   class="flex items-center space-x-3 text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition group min-w-0">
+                   class="flex items-center space-x-3 text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300 transition group min-w-0">
                     <div class="text-right min-w-0">
                         <div class="text-sm text-gray-500 dark:text-gray-400">Next</div>
                         <div class="font-medium truncate overflow-hidden min-w-0">Part {navigation.nextPart.number}: {navigation.nextPart.title}</div>
                     </div>
-                    <div class="flex items-center justify-center w-12 h-12 bg-blue-100 dark:bg-blue-900 rounded-full group-hover:bg-blue-200 dark:group-hover:bg-blue-800 transition">
+                    <div class="flex items-center justify-center w-12 h-12 bg-teal-100 dark:bg-teal-900 rounded-full group-hover:bg-teal-200 dark:group-hover:bg-teal-800 transition">
                         <i class="fas fa-arrow-right text-lg" aria-hidden="true"></i>
                     </div>
                 </a>
@@ -385,19 +385,19 @@ Best regards`;
 
 <!-- CTA Section -->
 <slot name="cta">
-    <section class="py-12 bg-blue-600 dark:bg-blue-700 text-white">
+    <section class="py-12 bg-teal-600 dark:bg-teal-700 text-white">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <h2 class="text-2xl md:text-3xl font-bold mb-4">Enjoying the Series?</h2>
-            <p class="text-blue-100 dark:text-blue-200 mb-6 text-lg">
+            <p class="text-teal-100 dark:text-teal-200 mb-6 text-lg">
                 Share your thoughts or questions about AI-powered development.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
                 <a href={generateFeedbackEmail()}
-                   class="bg-white text-blue-600 px-6 py-3 rounded-full font-medium hover:bg-gray-100 transition shadow-lg">
+                   class="bg-white text-teal-600 px-6 py-3 rounded-full font-medium hover:bg-gray-100 transition shadow-lg">
                     <i class="fas fa-envelope mr-2" aria-hidden="true"></i>Send Feedback
                 </a>
                 <a href="https://www.linkedin.com/in/keepsrunning/" target="_blank"
-                   class="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 py-3 rounded-full font-medium transition">
+                   class="border-2 border-white text-white hover:bg-white hover:text-teal-600 px-6 py-3 rounded-full font-medium transition">
                     <i class="fab fa-linkedin mr-2" aria-hidden="true"></i>Discuss on LinkedIn
                 </a>
             </div>

--- a/src/lib/components/MorePosts.svelte
+++ b/src/lib/components/MorePosts.svelte
@@ -43,7 +43,7 @@
 		<div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
 			<div class="mb-8 flex items-end justify-between gap-4">
 				<div>
-					<p class="mb-1 text-xs font-semibold uppercase tracking-widest text-blue-600 dark:text-blue-400">
+					<p class="mb-1 text-xs font-semibold uppercase tracking-widest text-teal-600 dark:text-teal-400">
 						Keep reading
 					</p>
 					<h2 id="more-posts-heading" class="font-serif text-2xl font-semibold text-gray-900 dark:text-white">
@@ -51,8 +51,8 @@
 					</h2>
 				</div>
 				<a
-					href="/#writing"
-					class="hidden shrink-0 items-center gap-2 text-sm font-medium text-blue-700 transition hover:gap-3 hover:underline dark:text-blue-400 sm:inline-flex sm:min-h-[44px]"
+					href="/blog"
+					class="hidden shrink-0 items-center gap-2 text-sm font-medium text-teal-700 transition hover:gap-3 hover:underline dark:text-teal-400 sm:inline-flex sm:min-h-[44px]"
 				>
 					All posts <i class="fas fa-arrow-right text-xs" aria-hidden="true"></i>
 				</a>
@@ -62,15 +62,15 @@
 				{#each posts as post (post.slug)}
 					<a
 						href={'/blog/' + post.slug}
-						class="group flex flex-col rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-blue-300 hover:shadow-md dark:border-gray-800 dark:bg-gray-900 dark:hover:border-blue-700"
+						class="group flex flex-col rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:border-teal-300 hover:shadow-md dark:border-gray-800 dark:bg-gray-900 dark:hover:border-teal-700"
 					>
 						<div
-							class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10 text-blue-600 dark:text-blue-400"
+							class="mb-4 flex h-10 w-10 items-center justify-center rounded-lg bg-teal-500/10 text-teal-600 dark:text-teal-400"
 						>
 							<i class="fas {post.icon}" aria-hidden="true"></i>
 						</div>
 						<h3
-							class="mb-2 font-serif text-lg font-semibold leading-snug text-gray-900 transition group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300"
+							class="mb-2 font-serif text-lg font-semibold leading-snug text-gray-900 transition group-hover:text-teal-700 dark:text-white dark:group-hover:text-teal-300"
 						>
 							{post.title}
 						</h3>
@@ -78,7 +78,7 @@
 							{post.description}
 						</p>
 						<span
-							class="inline-flex items-center gap-2 text-sm font-medium text-blue-700 transition group-hover:gap-3 dark:text-blue-400"
+							class="inline-flex items-center gap-2 text-sm font-medium text-teal-700 transition group-hover:gap-3 dark:text-teal-400"
 						>
 							Read post <i class="fas fa-arrow-right text-xs" aria-hidden="true"></i>
 						</span>
@@ -88,8 +88,8 @@
 
 			<div class="mt-6 sm:hidden">
 				<a
-					href="/#writing"
-					class="inline-flex min-h-[44px] items-center gap-2 text-sm font-medium text-blue-700 hover:underline dark:text-blue-400"
+					href="/blog"
+					class="inline-flex min-h-[44px] items-center gap-2 text-sm font-medium text-teal-700 hover:underline dark:text-teal-400"
 				>
 					All posts <i class="fas fa-arrow-right text-xs" aria-hidden="true"></i>
 				</a>

--- a/src/lib/data/blogPosts.ts
+++ b/src/lib/data/blogPosts.ts
@@ -4,6 +4,10 @@ export interface BlogPostMeta {
 	description: string;
 	/** Font Awesome icon class (without the leading `fas`). */
 	icon: string;
+	/** ISO publish date (YYYY-MM-DD). Mirrors each post's JSON-LD `datePublished`. */
+	date: string;
+	/** Compact label (2-4 words) for tight spaces like the rail's "Latest" list. */
+	shortTitle: string;
 }
 
 /**
@@ -17,55 +21,87 @@ export const blogPosts: BlogPostMeta[] = [
 		title: 'Loop Engineering: Building Web Apps with an Agent in the Loop',
 		description:
 			'Why an AI agent needs a governed loop of observation, objective gates, iteration, and honest stopping to ship reliable web apps.',
-		icon: 'fa-arrows-rotate'
+		icon: 'fa-arrows-rotate',
+		date: '2026-07-10',
+		shortTitle: 'Loop Engineering'
 	},
 	{
 		slug: 'building-deckmark',
 		title: 'Building Deckmark: Closing the Feedback Loop for AI-Generated Slide Decks',
 		description:
 			'An MCP server that lets you click directly on slide elements to give feedback to an AI agent. Why I built it, and the human-in-the-loop pattern behind it.',
-		icon: 'fa-wand-magic-sparkles'
+		icon: 'fa-wand-magic-sparkles',
+		date: '2026-05-25',
+		shortTitle: 'Building Deckmark'
 	},
 	{
 		slug: 'nearbygame-what-i-learned',
 		title: "What I Learned Building a Walking Game With AI's Help",
 		description:
 			'Geography, ambient audio, and the pain of Microsoft Store IAP — a year of solo dev notes from building NearbyGame.',
-		icon: 'fa-route'
+		icon: 'fa-route',
+		date: '2026-05-11',
+		shortTitle: 'NearbyGame: Lessons'
 	},
 	{
 		slug: 'app-flow-first-pilot',
 		title: 'App Flow: First Pilot',
 		description:
 			'A practical pilot of disposable micro-apps that chain from Squad Shuffer to Group Qualifier to Tournament Bracket, with optional paths for different match formats.',
-		icon: 'fa-link'
+		icon: 'fa-link',
+		date: '2026-04-18',
+		shortTitle: 'App Flow: First Pilot'
 	},
 	{
 		slug: 'nearbygame-pivot',
 		title: 'How I Pivoted NearbyGame and Used AI to Go From 0 to 1',
 		description:
 			'Why I abandoned a venue-discovery idea, reframed the problem with AI, and turned NearbyGame into a calm walking experience built for one user first.',
-		icon: 'fa-route'
+		icon: 'fa-route',
+		date: '2026-04-03',
+		shortTitle: 'NearbyGame Pivot'
 	},
 	{
 		slug: 'introducing-crossit',
 		title: 'Introducing CrossIt: A Lightweight Habit Helper',
 		description:
 			'A simple local-first habit helper focused on one action: complete a routine and cross it off.',
-		icon: 'fa-check-double'
+		icon: 'fa-check-double',
+		date: '2026-03-19',
+		shortTitle: 'Introducing CrossIt'
 	},
 	{
 		slug: 'minibreaks-pivot',
 		title: 'MiniBreaks Pivot: From Wellness to Micro-Apps',
 		description:
 			'Why I pivoted MiniBreaks into a weekly micro-app experiment, and how I structured AI roles to ship one tiny app every week.',
-		icon: 'fa-leaf'
+		icon: 'fa-leaf',
+		date: '2026-03-17',
+		shortTitle: 'MiniBreaks Pivot'
 	},
 	{
 		slug: 'why-i-build-nocloud-chat',
 		title: 'Why Do I Build NoCloud Chat',
 		description:
 			'Why I built a local-first chat app with no registration and no cloud dependency.',
-		icon: 'fa-cloud'
+		icon: 'fa-cloud',
+		date: '2026-03-10',
+		shortTitle: 'NoCloud Chat'
 	}
 ];
+
+/** Posts sorted newest-first by publish date. */
+export const recentPosts: BlogPostMeta[] = [...blogPosts].sort(
+	(a, b) => b.date.localeCompare(a.date)
+);
+
+/** The N most recently published posts (newest first). */
+export function getRecentPosts(count = 4): BlogPostMeta[] {
+	return recentPosts.slice(0, count);
+}
+
+/** Human-readable publish date, e.g. "Jul 10, 2026". */
+export function formatPostDate(iso: string): string {
+	const d = new Date(iso + 'T00:00:00');
+	return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,10 +2,14 @@
 	import '../app.css';
 	import { onMount, onDestroy } from 'svelte';
 	import { afterNavigate } from '$app/navigation';
+	import { page } from '$app/stores';
+	import { getRecentPosts } from '$lib/data/blogPosts';
 
 	let { children } = $props();
 
-	let mobileMenuOpen = $state(false);
+	const latestPosts = getRecentPosts(3);
+
+	let drawerOpen = $state(false);
 	let scrolled = $state(false);
 	let scrollHandler: (() => void) | null = null;
 
@@ -19,17 +23,14 @@
 			if (!savedTheme) localStorage.setItem('theme', 'light');
 		}
 
-		// Nav scroll effect
 		scrollHandler = () => {
-			scrolled = window.scrollY > 50;
+			scrolled = window.scrollY > 40;
 		};
 		window.addEventListener('scroll', scrollHandler, { passive: true });
 	});
 
 	onDestroy(() => {
-		if (scrollHandler) {
-			window.removeEventListener('scroll', scrollHandler);
-		}
+		if (scrollHandler) window.removeEventListener('scroll', scrollHandler);
 	});
 
 	function toggleTheme() {
@@ -37,20 +38,29 @@
 		localStorage.setItem('theme', isDark ? 'dark' : 'light');
 	}
 
-	function closeMobileMenu() {
-		mobileMenuOpen = false;
+	function closeDrawer() {
+		drawerOpen = false;
 	}
 
-	// Scroll to hash anchor after client-side navigation (e.g. from /mosaic to /#writing)
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') drawerOpen = false;
+	}
+
+	// Primary route links get aria-current; hash links stay plain (same-page anchors)
+	function isActive(path: string): boolean {
+		const p = $page.url.pathname;
+		if (path === '/') return p === '/';
+		return p === path || p.startsWith(path + '/');
+	}
+
+	// Scroll to hash anchor after client-side navigation, and close the drawer
 	afterNavigate(({ to }) => {
+		drawerOpen = false;
 		const hash = to?.url?.hash;
 		if (hash) {
-			// Wait for DOM to update before scrolling
 			requestAnimationFrame(() => {
 				const el = document.querySelector(hash);
-				if (el) {
-					el.scrollIntoView({ behavior: 'smooth' });
-				}
+				if (el) el.scrollIntoView({ behavior: 'smooth' });
 			});
 		}
 	});
@@ -98,166 +108,211 @@
 	></script>
 </svelte:head>
 
+<svelte:window onkeydown={onKeydown} />
+
 <!-- Skip link: first focusable element so keyboard/AT users can bypass the nav (WCAG 2.4.1) -->
 <a
 	href="#main-content"
-	class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:inline-flex focus:min-h-[44px] focus:items-center focus:rounded-lg focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white focus:shadow-lg"
+	class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:inline-flex focus:min-h-[44px] focus:items-center focus:rounded-lg focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg"
+	style="background: var(--accent); color: var(--on-accent);"
 >
 	Skip to main content
 </a>
 
-<!-- Navigation -->
-<nav
-	class="nav-glass fixed left-0 right-0 top-0 z-50 transition-all duration-300"
-	class:scrolled
->
-	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-		<div class="flex h-16 items-center justify-between">
-			<a href="/" class="flex items-center text-xl font-bold">
-				<span class="gradient-text font-serif">hongincanada</span>
+<!-- Reusable rail body (shared by desktop rail + mobile drawer) -->
+{#snippet railBody()}
+	<!-- Brand -->
+	<a href="/" onclick={closeDrawer} class="block px-2">
+		<span class="flex items-center gap-3">
+			<img
+				src="/profile.png"
+				alt="Hong"
+				class="h-11 w-11 flex-shrink-0 rounded-full object-cover ring-1"
+				style="--tw-ring-color: var(--border-strong); background: var(--surface-2);"
+			/>
+			<span class="font-serif text-lg leading-tight" style="color: var(--text);">Hong</span>
+		</span>
+		<span class="rail-tags mt-3">
+			<span class="rail-tag">Product</span>
+			<span class="rail-tag">AI Native</span>
+			<span class="rail-tag">HCI</span>
+			<span class="rail-tag">Eng Lead</span>
+		</span>
+	</a>
+
+	<!-- Explore -->
+	<nav class="rail-section rail-section-first space-y-1" aria-label="Primary">
+		<p class="mono-label rail-label px-3">Explore</p>
+		<a href="/" onclick={closeDrawer} class="rail-link" aria-current={isActive('/') ? 'page' : undefined}>
+			<i class="fas fa-house" aria-hidden="true"></i><span>Home</span>
+		</a>
+		<a href="/#projects" onclick={closeDrawer} class="rail-link">
+			<i class="fas fa-cube" aria-hidden="true"></i><span>Projects</span>
+		</a>
+		<a href="/#writing" onclick={closeDrawer} class="rail-link">
+			<i class="fas fa-pen-nib" aria-hidden="true"></i><span>Writing</span>
+		</a>
+		<a href="/#about" onclick={closeDrawer} class="rail-link">
+			<i class="fas fa-circle-user" aria-hidden="true"></i><span>About</span>
+		</a>
+	</nav>
+
+	<!-- Series & Tools -->
+	<nav class="rail-section space-y-1" aria-label="Series and tools">
+		<p class="mono-label rail-label px-3">Series &amp; Tools</p>
+		<a href="/ai-workflow-review" onclick={closeDrawer} class="rail-link" aria-current={isActive('/ai-workflow-review') ? 'page' : undefined}>
+			<i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i><span>AI Review</span>
+		</a>
+		<a href="/blog/minibreaks-pivot" onclick={closeDrawer} class="rail-link" aria-current={isActive('/blog/minibreaks-pivot') ? 'page' : undefined}>
+			<i class="fas fa-leaf" aria-hidden="true"></i><span>Minibreaks</span>
+		</a>
+		<a href="/mosaic" onclick={closeDrawer} class="rail-link" aria-current={isActive('/mosaic') ? 'page' : undefined}>
+			<i class="fas fa-table-cells-large" aria-hidden="true"></i><span>Mosaic</span>
+		</a>
+	</nav>
+
+	<!-- Latest posts: hidden on short viewports so the footer (social/theme
+	     toggle) stays visible instead of pushing it off-screen or scrolling -->
+	<nav class="rail-section rail-latest space-y-0.5" aria-label="Latest posts">
+		<p class="mono-label rail-label px-3">Latest</p>
+		{#each latestPosts as post (post.slug)}
+			<a
+				href={'/blog/' + post.slug}
+				onclick={closeDrawer}
+				class="rail-post"
+				aria-current={isActive('/blog/' + post.slug) ? 'page' : undefined}
+			>
+				<i class="fas {post.icon}" aria-hidden="true"></i>
+				<span class="rail-post-title">{post.shortTitle}</span>
 			</a>
+		{/each}
+		<a href="/blog" onclick={closeDrawer} class="rail-link" aria-current={$page.url.pathname === '/blog' ? 'page' : undefined}>
+			<i class="fas fa-arrow-right" aria-hidden="true"></i><span>All writing</span>
+		</a>
+	</nav>
 
-			<!-- Desktop nav -->
-			<div class="hidden items-center space-x-8 md:flex">
-				<a href="/#about" class="text-gray-600 dark:text-gray-400 transition hover:text-gray-900 dark:hover:text-white">About</a>
-				<a href="/#projects" class="text-gray-600 dark:text-gray-400 transition hover:text-gray-900 dark:hover:text-white">Projects</a>
-				<a href="/#writing" class="text-gray-600 dark:text-gray-400 transition hover:text-gray-900 dark:hover:text-white">Writing</a>
-				<a href="/ai-workflow-review" class="text-gray-600 dark:text-gray-400 transition hover:text-gray-900 dark:hover:text-white">AI Review</a>
-				<a
-					href="/#contact"
-					class="rounded-full border border-blue-500/50 bg-blue-500/10 px-4 py-2 text-blue-600 dark:text-blue-400 transition hover:bg-blue-500/20 hover:text-blue-800 dark:hover:text-white"
-				>
-					Contact
+	<!-- Bottom cluster -->
+	<div class="rail-bottom mt-auto space-y-3">
+		<a
+			href="/#contact"
+			onclick={closeDrawer}
+			class="flex min-h-[44px] items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold transition-colors"
+			style="background: var(--accent); color: var(--on-accent);"
+		>
+			<i class="fas fa-paper-plane" aria-hidden="true"></i> Get in touch
+		</a>
+		<div class="flex items-center justify-between px-1">
+			<div class="flex items-center gap-1">
+				<a href="https://github.com/sowenzhang" target="_blank" rel="noopener noreferrer" class="flex h-11 w-11 items-center justify-center rounded-lg transition-colors hover:bg-[var(--accent-soft)]" style="color: var(--faint);" aria-label="GitHub profile">
+					<i class="fab fa-github text-lg" aria-hidden="true"></i>
 				</a>
-				<button
-					onclick={toggleTheme}
-					class="text-gray-600 dark:text-gray-400 transition hover:text-gray-900 dark:hover:text-white"
-					aria-label="Toggle theme"
-				>
-					<i class="fas fa-adjust"></i>
-				</button>
+				<a href="https://www.linkedin.com/in/keepsrunning/" target="_blank" rel="noopener noreferrer" class="flex h-11 w-11 items-center justify-center rounded-lg transition-colors hover:bg-[var(--accent-soft)]" style="color: var(--faint);" aria-label="LinkedIn profile">
+					<i class="fab fa-linkedin-in text-lg" aria-hidden="true"></i>
+				</a>
+				<a href="https://www.strava.com/athletes/6051008" target="_blank" rel="noopener noreferrer" class="flex h-11 w-11 items-center justify-center rounded-lg transition-colors hover:bg-[var(--accent-soft)]" style="color: var(--faint);" aria-label="Strava profile">
+					<i class="fab fa-strava text-lg" aria-hidden="true"></i>
+				</a>
 			</div>
-
-			<!-- Mobile menu button -->
-			<div class="flex items-center gap-3 md:hidden">
-				<button
-					onclick={toggleTheme}
-					class="text-gray-600 dark:text-gray-400 transition hover:text-gray-900 dark:hover:text-white"
-					aria-label="Toggle theme"
-				>
-					<i class="fas fa-adjust"></i>
-				</button>
-				<button
-					onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
-					class="text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
-					aria-label="Toggle menu"
-				>
-					<i class="fas {mobileMenuOpen ? 'fa-times' : 'fa-bars'} text-xl"></i>
-				</button>
-			</div>
+			<button
+				onclick={toggleTheme}
+				class="flex h-11 w-11 items-center justify-center rounded-lg transition-colors hover:bg-[var(--accent-soft)]"
+				style="color: var(--faint);"
+				aria-label="Toggle theme"
+			>
+				<i class="fas fa-circle-half-stroke text-lg" aria-hidden="true"></i>
+			</button>
 		</div>
 	</div>
+{/snippet}
 
-	<!-- Mobile menu -->
-	{#if mobileMenuOpen}
-		<div class="border-t border-gray-200 dark:border-white/5 bg-white/95 dark:bg-gray-950/95 backdrop-blur-lg md:hidden">
-			<div class="space-y-1 px-4 py-4">
-				<a
-					href="/#about"
-					onclick={closeMobileMenu}
-					class="block rounded-lg px-3 py-2 text-gray-700 dark:text-gray-300 transition hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-900 dark:hover:text-white"
-				>
-					About
-				</a>
-				<a
-					href="/#projects"
-					onclick={closeMobileMenu}
-					class="block rounded-lg px-3 py-2 text-gray-700 dark:text-gray-300 transition hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-900 dark:hover:text-white"
-				>
-					Projects
-				</a>
-				<a
-					href="/#writing"
-					onclick={closeMobileMenu}
-					class="block rounded-lg px-3 py-2 text-gray-700 dark:text-gray-300 transition hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-900 dark:hover:text-white"
-				>
-					Writing
-				</a>
-				<a
-					href="/ai-workflow-review"
-					onclick={closeMobileMenu}
-					class="block rounded-lg px-3 py-2 text-gray-700 dark:text-gray-300 transition hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-900 dark:hover:text-white"
-				>
-					AI Review
-				</a>
-				<a
-					href="/#contact"
-					onclick={closeMobileMenu}
-					class="mt-2 block rounded-lg bg-blue-500/10 px-3 py-2 text-center text-blue-600 dark:text-blue-400 transition hover:bg-blue-500/20"
-				>
-					Contact
-				</a>
-			</div>
+<!-- Desktop left rail -->
+<aside class="rail fixed inset-y-0 left-0 z-40 hidden w-64 flex-col overflow-y-auto p-5 lg:flex">
+	{@render railBody()}
+</aside>
+
+<!-- Mobile top bar -->
+<header class="nav-glass fixed inset-x-0 top-0 z-40 lg:hidden" class:scrolled>
+	<div class="flex h-16 items-center justify-between px-4">
+		<a href="/" class="flex items-center gap-2.5">
+			<img src="/profile.png" alt="Hong" class="h-8 w-8 rounded-full object-cover" />
+			<span class="font-serif text-lg" style="color: var(--text);">Hong</span>
+		</a>
+		<div class="flex items-center gap-1">
+			<button onclick={toggleTheme} class="flex h-11 w-11 items-center justify-center rounded-lg" style="color: var(--muted);" aria-label="Toggle theme">
+				<i class="fas fa-circle-half-stroke" aria-hidden="true"></i>
+			</button>
+			<button
+				onclick={() => (drawerOpen = !drawerOpen)}
+				class="flex h-11 w-11 items-center justify-center rounded-lg"
+				style="color: var(--muted);"
+				aria-label="Toggle menu"
+				aria-expanded={drawerOpen}
+			>
+				<i class="fas {drawerOpen ? 'fa-times' : 'fa-bars'} text-xl" aria-hidden="true"></i>
+			</button>
 		</div>
-	{/if}
-</nav>
+	</div>
+</header>
 
-<!-- Spacer for fixed nav -->
-<div class="h-16"></div>
+<!-- Mobile drawer -->
+{#if drawerOpen}
+	<div class="fixed inset-0 z-50 lg:hidden">
+		<button
+			class="absolute inset-0 h-full w-full"
+			style="background: rgba(0,0,0,0.5);"
+			onclick={closeDrawer}
+			aria-label="Close menu"
+			tabindex="-1"
+		></button>
+		<aside class="rail absolute inset-y-0 left-0 flex w-72 max-w-[84vw] flex-col overflow-y-auto p-5" style="background: var(--surface);">
+			{@render railBody()}
+		</aside>
+	</div>
+{/if}
 
-<main id="main-content" tabindex="-1">
-	{@render children()}
-</main>
+<!-- Content column, offset for the rail on desktop -->
+<div class="content-shell">
+	<!-- Spacer for the mobile top bar -->
+	<div class="h-16 lg:hidden"></div>
 
-<footer class="border-t border-gray-200 dark:border-white/5 bg-gray-50 dark:bg-gray-950 py-12 text-gray-900 dark:text-white transition-colors">
-	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-		<div class="flex flex-col items-center justify-between md:flex-row">
-			<div class="mb-6 md:mb-0">
-				<a href="/" class="flex items-center text-xl font-bold">
-					<span class="gradient-text font-serif">hongincanada</span>
-				</a>
-				<p class="mt-2 text-sm text-gray-500">Engineering Manager & Product Builder</p>
-			</div>
-			<div class="flex flex-col items-center md:items-end">
-				<div class="mb-4 flex space-x-5">
-					<a
-						href="https://github.com/sowenzhang"
-						target="_blank"
-						class="text-gray-400 dark:text-gray-500 transition hover:text-gray-900 dark:hover:text-white"
-						aria-label="GitHub profile"
-					>
-						<i class="fab fa-github text-lg"></i>
-					</a>
-					<a
-						href="https://www.linkedin.com/in/keepsrunning/"
-						target="_blank"
-						class="text-gray-400 dark:text-gray-500 transition hover:text-gray-900 dark:hover:text-white"
-						aria-label="LinkedIn profile"
-					>
-						<i class="fab fa-linkedin-in text-lg"></i>
-					</a>
-					<a
-						href="https://www.strava.com/athletes/6051008"
-						target="_blank"
-						class="text-gray-400 dark:text-gray-500 transition hover:text-gray-900 dark:hover:text-white"
-						aria-label="Strava profile"
-					>
-						<i class="fab fa-strava text-lg"></i>
-					</a>
+	<main id="main-content" tabindex="-1">
+		{@render children()}
+	</main>
+
+	<footer class="border-t py-12 transition-colors" style="border-color: var(--border); background: var(--surface-2); color: var(--text);">
+		<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+			<div class="flex flex-col items-center justify-between gap-6 md:flex-row">
+				<div class="text-center md:text-left">
+					<a href="/" class="font-serif text-xl" style="color: var(--text);">hongincanada</a>
+					<p class="mono-label mt-2">Product Builder · Engineering Leadership</p>
 				</div>
-				<p class="text-xs text-gray-400 dark:text-gray-600">&copy; 2026 Hong in Canada. All rights reserved.</p>
+				<div class="flex flex-col items-center gap-4 md:items-end">
+					<div class="flex gap-2">
+						<a href="https://github.com/sowenzhang" target="_blank" rel="noopener noreferrer" class="flex h-11 w-11 items-center justify-center rounded-lg transition-colors hover:bg-[var(--accent-soft)]" style="color: var(--faint);" aria-label="GitHub profile">
+							<i class="fab fa-github text-lg" aria-hidden="true"></i>
+						</a>
+						<a href="https://www.linkedin.com/in/keepsrunning/" target="_blank" rel="noopener noreferrer" class="flex h-11 w-11 items-center justify-center rounded-lg transition-colors hover:bg-[var(--accent-soft)]" style="color: var(--faint);" aria-label="LinkedIn profile">
+							<i class="fab fa-linkedin-in text-lg" aria-hidden="true"></i>
+						</a>
+						<a href="https://www.strava.com/athletes/6051008" target="_blank" rel="noopener noreferrer" class="flex h-11 w-11 items-center justify-center rounded-lg transition-colors hover:bg-[var(--accent-soft)]" style="color: var(--faint);" aria-label="Strava profile">
+							<i class="fab fa-strava text-lg" aria-hidden="true"></i>
+						</a>
+					</div>
+					<p class="text-xs" style="color: var(--faint);">&copy; 2026 Hong in Canada. All rights reserved.</p>
+				</div>
 			</div>
 		</div>
-	</div>
-</footer>
+	</footer>
+</div>
 
 <!-- Back to top -->
 <button
 	onclick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-	class="fixed bottom-8 right-8 flex h-12 w-12 items-center justify-center rounded-full border border-gray-300 dark:border-white/10 bg-white/80 dark:bg-gray-900/80 text-gray-500 dark:text-gray-400 shadow-lg backdrop-blur-sm transition hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-white {scrolled
+	class="fixed bottom-8 right-8 z-30 flex h-12 w-12 items-center justify-center rounded-full border shadow-lg backdrop-blur-sm transition {scrolled
 		? 'opacity-100'
 		: 'pointer-events-none opacity-0'}"
+	style="border-color: var(--border-strong); background: color-mix(in srgb, var(--surface) 85%, transparent); color: var(--muted);"
 	aria-label="Back to top"
 >
-	<i class="fas fa-arrow-up"></i>
+	<i class="fas fa-arrow-up" aria-hidden="true"></i>
 </button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -136,8 +136,8 @@
 		>
 			<a
 				href="#projects"
-				class="rounded-full px-6 py-3 text-sm font-semibold text-white transition-colors"
-				style="background: var(--accent);"
+				class="rounded-full px-6 py-3 text-sm font-semibold transition-colors"
+				style="background: var(--accent); color: var(--on-accent);"
 				onmouseover={(e) => (e.currentTarget.style.background = 'var(--accent-strong)')}
 				onfocus={(e) => (e.currentTarget.style.background = 'var(--accent-strong)')}
 				onmouseout={(e) => (e.currentTarget.style.background = 'var(--accent)')}
@@ -177,10 +177,10 @@
 <!-- ============================================ -->
 <!-- PROJECTS: What I Build                       -->
 <!-- ============================================ -->
-<section id="projects" class="section-glow py-24" style="background: var(--bg);" itemscope itemtype="https://schema.org/CreativeWork">
+<section id="projects" class="section-glow py-16" style="background: var(--bg);" itemscope itemtype="https://schema.org/CreativeWork">
 	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 		<ScrollReveal>
-			<div class="mb-16 text-center">
+			<div class="mb-12 text-center">
 				<p class="eyebrow mb-3">Projects</p>
 				<h2 class="font-serif text-4xl font-medium md:text-5xl" style="color: var(--text);">What I Build</h2>
 				<p class="mx-auto mt-4 max-w-xl" style="color: var(--muted);">
@@ -345,12 +345,59 @@
 </section>
 
 <!-- ============================================ -->
-<!-- WRITING: What I Think                        -->
+<!-- FREE AI REVIEW: Featured offering            -->
 <!-- ============================================ -->
-<section id="writing" class="section-glow py-24" style="background: var(--surface-2);">
+<section class="py-12" style="background: var(--bg);">
 	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 		<ScrollReveal>
-			<div class="mb-16 text-center">
+			<div
+				class="glass-card overflow-hidden rounded-2xl p-8 md:p-10"
+				style="background: linear-gradient(135deg, var(--accent-soft), transparent 70%);"
+			>
+				<div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+					<div class="max-w-xl">
+						<p class="eyebrow mb-3">Free · Limited slots</p>
+						<h2 class="font-serif text-3xl font-medium md:text-4xl" style="color: var(--text);">
+							Free AI Workflow Review
+						</h2>
+						<p class="mt-3 leading-relaxed" style="color: var(--muted);">
+							Send me one repetitive workflow. I may send back a short written review with practical
+							AI ideas, prompts, risks, and next steps — no sales pitch.
+						</p>
+					</div>
+					<div class="flex flex-shrink-0 flex-wrap items-center gap-3">
+						<a
+							href="/ai-workflow-review"
+							class="inline-flex items-center gap-2 rounded-full px-6 py-3 text-sm font-semibold transition-colors"
+							style="background: var(--accent); color: var(--on-accent);"
+							onmouseover={(e) => (e.currentTarget.style.background = 'var(--accent-strong)')}
+							onfocus={(e) => (e.currentTarget.style.background = 'var(--accent-strong)')}
+							onmouseout={(e) => (e.currentTarget.style.background = 'var(--accent)')}
+							onblur={(e) => (e.currentTarget.style.background = 'var(--accent)')}
+						>
+							<i class="fas fa-wand-magic-sparkles"></i> Get your review
+						</a>
+						<a
+							href="/ai-workflow-review#examples"
+							class="inline-flex items-center gap-2 text-sm font-semibold underline decoration-1 underline-offset-4"
+							style="color: var(--accent);"
+						>
+							See examples →
+						</a>
+					</div>
+				</div>
+			</div>
+		</ScrollReveal>
+	</div>
+</section>
+
+<!-- ============================================ -->
+<!-- WRITING: What I Think                        -->
+<!-- ============================================ -->
+<section id="writing" class="section-glow py-16" style="background: var(--surface-2);">
+	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+		<ScrollReveal>
+			<div class="mb-12 text-center">
 				<p class="eyebrow mb-3">Writing</p>
 				<h2 class="font-serif text-4xl font-medium md:text-5xl" style="color: var(--text);">What I Think</h2>
 				<p class="mx-auto mt-4 max-w-xl" style="color: var(--muted);">
@@ -451,94 +498,6 @@
 				</article>
 
 				<article class="h-full">
-					<a href="/blog/nearbygame-pivot" class="glass-card group flex h-full min-h-[240px] flex-col rounded-2xl p-6">
-						<div class="mb-4 flex items-center gap-3">
-							<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-500/10">
-								<i class="fas fa-route text-emerald-400"></i>
-							</div>
-							<span class="rounded-full bg-emerald-500/10 px-2.5 py-1 text-[10px] font-medium text-emerald-400">
-								BLOG
-							</span>
-						</div>
-						<h3 class="writing-card-title mb-2 text-xl font-bold text-gray-900 transition group-hover:text-emerald-300 dark:text-white">
-							How I Pivoted NearbyGame and Used AI to Go From 0 to 1
-						</h3>
-						<p class="writing-card-description mb-4 flex-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
-							Why I abandoned a venue-discovery idea, reframed the problem with AI, and turned NearbyGame into a calm walking experience built for one user first.
-						</p>
-						<span class="flex items-center gap-2 text-sm font-medium text-emerald-400 transition group-hover:gap-3">
-							Read Post <i class="fas fa-arrow-right text-xs"></i>
-						</span>
-					</a>
-				</article>
-
-				<article class="h-full">
-					<a href="/blog/introducing-crossit" class="glass-card group flex h-full min-h-[240px] flex-col rounded-2xl p-6">
-						<div class="mb-4 flex items-center gap-3">
-							<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-teal-500/10">
-								<i class="fas fa-check-double text-teal-400"></i>
-							</div>
-							<span class="rounded-full bg-teal-500/10 px-2.5 py-1 text-[10px] font-medium text-teal-400">
-								BLOG
-							</span>
-						</div>
-						<h3 class="writing-card-title mb-2 text-xl font-bold text-gray-900 dark:text-white group-hover:text-teal-300 transition">
-							Introducing CrossIt: A Lightweight Habit Helper
-						</h3>
-						<p class="writing-card-description mb-4 flex-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
-							A simple local-first habit helper focused on one action: complete a routine and cross it off.
-						</p>
-						<span class="flex items-center gap-2 text-sm font-medium text-teal-400 transition group-hover:gap-3">
-							Read Post <i class="fas fa-arrow-right text-xs"></i>
-						</span>
-					</a>
-				</article>
-
-				<article class="h-full">
-					<a href="/blog/minibreaks-pivot" class="glass-card group flex h-full min-h-[240px] flex-col rounded-2xl p-6">
-						<div class="mb-4 flex items-center gap-3">
-							<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-orange-500/10">
-								<i class="fas fa-leaf text-orange-400"></i>
-							</div>
-							<span class="rounded-full bg-orange-500/10 px-2.5 py-1 text-[10px] font-medium text-orange-400">
-								BLOG
-							</span>
-						</div>
-						<h3 class="writing-card-title mb-2 text-xl font-bold text-gray-900 dark:text-white group-hover:text-orange-300 transition">
-							MiniBreaks Pivot: From Wellness to Micro-Apps
-						</h3>
-						<p class="writing-card-description mb-4 flex-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
-							Why I pivoted MiniBreaks into a weekly micro-app experiment, and how I structured AI roles to ship one tiny app every week.
-						</p>
-						<span class="flex items-center gap-2 text-sm font-medium text-orange-400 transition group-hover:gap-3">
-							Read Post <i class="fas fa-arrow-right text-xs"></i>
-						</span>
-					</a>
-				</article>
-
-				<article class="h-full">
-					<a href="/blog/why-i-build-nocloud-chat" class="glass-card group flex h-full min-h-[240px] flex-col rounded-2xl p-6">
-						<div class="mb-4 flex items-center gap-3">
-							<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-cyan-500/10">
-								<i class="fas fa-cloud text-cyan-400"></i>
-							</div>
-							<span class="rounded-full bg-cyan-500/10 px-2.5 py-1 text-[10px] font-medium text-cyan-400">
-								BLOG
-							</span>
-						</div>
-						<h3 class="writing-card-title mb-2 text-xl font-bold text-gray-900 dark:text-white group-hover:text-cyan-300 transition">
-							Why Do I Build NoCloud Chat
-						</h3>
-						<p class="writing-card-description mb-4 flex-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
-							Why I built a local-first chat app with no registration and no cloud dependency.
-						</p>
-						<span class="flex items-center gap-2 text-sm font-medium text-cyan-400 transition group-hover:gap-3">
-							Read Post <i class="fas fa-arrow-right text-xs"></i>
-						</span>
-					</a>
-				</article>
-
-				<article class="h-full">
 					<a href="/mosaic" class="glass-card group flex h-full min-h-[240px] flex-col rounded-2xl p-6">
 						<div class="mb-4 flex items-center gap-3">
 							<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-500/10">
@@ -584,11 +543,17 @@
 			</div>
 		</ScrollReveal>
 
-		<!-- Coming soon teaser -->
+		<!-- View all writing -->
 		<ScrollReveal delay={400}>
-			<p class="mt-10 text-center text-sm text-gray-600">
-				<i class="fas fa-pen-nib mr-1"></i> More articles in the works — stay tuned.
-			</p>
+			<div class="mt-12 text-center">
+				<a
+					href="/blog"
+					class="inline-flex items-center gap-2 rounded-full border px-6 py-3 text-sm font-semibold transition-colors hover:bg-[var(--accent-soft)]"
+					style="border-color: var(--border-strong); color: var(--text);"
+				>
+					View all writing <i class="fas fa-arrow-right text-xs"></i>
+				</a>
+			</div>
 		</ScrollReveal>
 	</div>
 </section>
@@ -614,10 +579,10 @@
 <!-- ============================================ -->
 <!-- ABOUT: The Journey                           -->
 <!-- ============================================ -->
-<section id="about" class="section-glow py-24" style="background: var(--bg);" itemscope itemtype="https://schema.org/AboutPage">
+<section id="about" class="section-glow py-16" style="background: var(--bg);" itemscope itemtype="https://schema.org/AboutPage">
 	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 		<ScrollReveal>
-			<div class="mb-16 text-center">
+			<div class="mb-12 text-center">
 				<p class="eyebrow mb-3">Background</p>
 				<h2 class="font-serif text-4xl font-medium md:text-5xl" style="color: var(--text);">The Journey</h2>
 			</div>
@@ -687,7 +652,7 @@ Never stop building products in the last 10+ years.
 <!-- ============================================ -->
 <!-- THE HUMAN: Personality & Interests           -->
 <!-- ============================================ -->
-<section class="section-glow py-24" style="background: var(--surface-2);">
+<section class="section-glow py-16" style="background: var(--surface-2);">
 	<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
 		<ScrollReveal>
 			<div class="mb-12 text-center">
@@ -779,7 +744,7 @@ Never stop building products in the last 10+ years.
 <!-- ============================================ -->
 <!-- CONNECT: Let's Talk                          -->
 <!-- ============================================ -->
-<section id="contact" class="section-glow py-24" style="background: var(--bg);">
+<section id="contact" class="section-glow py-16" style="background: var(--bg);">
 	<div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
 		<ScrollReveal>
 			<div class="mb-12 text-center">

--- a/src/routes/ai-workflow-review/+page.svelte
+++ b/src/routes/ai-workflow-review/+page.svelte
@@ -179,7 +179,7 @@
 			<div class="flex flex-wrap items-center justify-center gap-4">
 				<a
 					href="#send-workflow"
-					class="rounded-full border border-blue-500/50 bg-blue-500/10 px-6 py-3 text-sm font-medium text-blue-600 dark:text-blue-400 transition-colors hover:bg-blue-500/20 hover:text-blue-700 dark:hover:text-white"
+					class="rounded-full border border-teal-500/50 bg-teal-500/10 px-6 py-3 text-sm font-medium text-teal-600 dark:text-teal-400 transition-colors hover:bg-teal-500/20 hover:text-teal-700 dark:hover:text-white"
 				>
 					Send a Workflow
 				</a>
@@ -231,12 +231,12 @@
 		<div class="mx-auto max-w-2xl">
 			<div class="relative">
 				<!-- Connecting line -->
-				<div class="absolute left-6 top-6 bottom-6 w-px bg-gradient-to-b from-blue-500/40 via-blue-500/40 to-blue-500/40 md:left-8"></div>
+				<div class="absolute left-6 top-6 bottom-6 w-px bg-gradient-to-b from-teal-500/40 via-teal-500/40 to-teal-500/40 md:left-8"></div>
 
 				<ScrollReveal delay={100}>
 					<div class="relative mb-8 flex items-start gap-4 md:gap-6">
-						<div class="relative z-10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-500/10 border border-blue-500/20 md:h-16 md:w-16">
-							<span class="text-lg font-bold text-blue-400 md:text-xl">1</span>
+						<div class="relative z-10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-500/10 border border-teal-500/20 md:h-16 md:w-16">
+							<span class="text-lg font-bold text-teal-400 md:text-xl">1</span>
 						</div>
 						<div class="pt-2 md:pt-4">
 							<h3 class="mb-1 font-semibold text-gray-900 dark:text-white">You describe one workflow</h3>
@@ -247,8 +247,8 @@
 
 				<ScrollReveal delay={200}>
 					<div class="relative mb-8 flex items-start gap-4 md:gap-6">
-						<div class="relative z-10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-500/10 border border-blue-500/20 md:h-16 md:w-16">
-							<span class="text-lg font-bold text-blue-500 md:text-xl">2</span>
+						<div class="relative z-10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-500/10 border border-teal-500/20 md:h-16 md:w-16">
+							<span class="text-lg font-bold text-teal-500 md:text-xl">2</span>
 						</div>
 						<div class="pt-2 md:pt-4">
 							<h3 class="mb-1 font-semibold text-gray-900 dark:text-white">I review selected requests</h3>
@@ -259,8 +259,8 @@
 
 				<ScrollReveal delay={300}>
 					<div class="relative mb-8 flex items-start gap-4 md:gap-6">
-						<div class="relative z-10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-500/10 border border-blue-500/20 md:h-16 md:w-16">
-							<span class="text-lg font-bold text-blue-500 md:text-xl">3</span>
+						<div class="relative z-10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-500/10 border border-teal-500/20 md:h-16 md:w-16">
+							<span class="text-lg font-bold text-teal-500 md:text-xl">3</span>
 						</div>
 						<div class="pt-2 md:pt-4">
 							<h3 class="mb-1 font-semibold text-gray-900 dark:text-white">I send back a short written review</h3>
@@ -271,8 +271,8 @@
 
 				<ScrollReveal delay={400}>
 					<div class="relative flex items-start gap-4 md:gap-6">
-						<div class="relative z-10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-500/10 border border-blue-500/20 md:h-16 md:w-16">
-							<span class="text-lg font-bold text-blue-500 md:text-xl">4</span>
+						<div class="relative z-10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-500/10 border border-teal-500/20 md:h-16 md:w-16">
+							<span class="text-lg font-bold text-teal-500 md:text-xl">4</span>
 						</div>
 						<div class="pt-2 md:pt-4">
 							<h3 class="mb-1 font-semibold text-gray-900 dark:text-white">You decide whether to test it</h3>
@@ -300,23 +300,23 @@
 		<ScrollReveal delay={100}>
 			<ul class="space-y-3">
 				<li class="flex items-start gap-3">
-					<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+					<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 					<span class="text-gray-700 dark:text-gray-300">A small business owner with repeated customer questions, documents, or admin work</span>
 				</li>
 				<li class="flex items-start gap-3">
-					<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+					<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 					<span class="text-gray-700 dark:text-gray-300">A solo professional or consultant who creates similar proposals, reports, or follow-ups</span>
 				</li>
 				<li class="flex items-start gap-3">
-					<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+					<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 					<span class="text-gray-700 dark:text-gray-300">An educator or creator trying to turn notes, lessons, or ideas into reusable material</span>
 				</li>
 				<li class="flex items-start gap-3">
-					<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+					<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 					<span class="text-gray-700 dark:text-gray-300">A small team trying to use AI without buying a big system or starting a huge project</span>
 				</li>
 				<li class="flex items-start gap-3">
-					<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+					<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 					<span class="text-gray-700 dark:text-gray-300">A builder who has a messy workflow and wants a second opinion on where AI can help</span>
 				</li>
 			</ul>
@@ -326,7 +326,7 @@
 			<div class="mt-10 flex justify-center">
 				<a
 					href="#send-workflow"
-					class="rounded-full border border-blue-500/50 bg-blue-500/10 px-6 py-3 text-sm font-medium text-blue-600 dark:text-blue-400 transition-colors hover:bg-blue-500/20 hover:text-blue-700 dark:hover:text-white"
+					class="rounded-full border border-teal-500/50 bg-teal-500/10 px-6 py-3 text-sm font-medium text-teal-600 dark:text-teal-400 transition-colors hover:bg-teal-500/20 hover:text-teal-700 dark:hover:text-white"
 				>
 					Send a Workflow
 				</a>
@@ -380,7 +380,7 @@
 <section class="bg-white dark:bg-gray-950 py-12">
 	<div class="mx-auto max-w-3xl px-4 sm:px-6">
 		<ScrollReveal>
-			<div class="rounded-2xl border border-blue-500/20 bg-blue-500/5 p-5 md:p-6">
+			<div class="rounded-2xl border border-teal-500/20 bg-teal-500/5 p-5 md:p-6">
 				<h3 class="mb-3 font-serif text-xl font-semibold text-gray-900 dark:text-white">Still not sure?</h3>
 				<p class="mb-6 text-gray-600 dark:text-gray-400">
 					That's okay. Send a simple, anonymized version of the workflow and I'll decide whether it's something I can reasonably review.
@@ -388,7 +388,7 @@
 				<div class="flex justify-center">
 					<a
 						href="#send-workflow"
-						class="rounded-full border border-blue-500/50 bg-blue-500/10 px-6 py-3 text-sm font-medium text-blue-600 dark:text-blue-400 transition-colors hover:bg-blue-500/20 hover:text-blue-700 dark:hover:text-white"
+						class="rounded-full border border-teal-500/50 bg-teal-500/10 px-6 py-3 text-sm font-medium text-teal-600 dark:text-teal-400 transition-colors hover:bg-teal-500/20 hover:text-teal-700 dark:hover:text-white"
 					>
 						Send a Workflow
 					</a>
@@ -405,7 +405,7 @@
 	<div class="mx-auto max-w-5xl px-4 sm:px-6">
 		<ScrollReveal>
 			<div class="mb-12 text-center">
-				<p class="mb-2 text-sm font-medium tracking-widest uppercase text-blue-500">Examples</p>
+				<p class="mb-2 text-sm font-medium tracking-widest uppercase text-teal-500">Examples</p>
 				<h2 class="font-serif text-2xl font-semibold text-gray-900 dark:text-white md:text-3xl">Workflows that work well for this</h2>
 			</div>
 		</ScrollReveal>
@@ -413,8 +413,8 @@
 		<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 			<ScrollReveal delay={100}>
 				<div class="glass-card flex h-full min-h-[132px] items-start gap-4 rounded-xl p-5">
-					<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
-						<i class="fas fa-envelope text-blue-400"></i>
+					<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-teal-500/10">
+						<i class="fas fa-envelope text-teal-400"></i>
 					</div>
 					<div class="flex min-h-full flex-1 flex-col">
 						<h3 class="min-h-[3rem] font-semibold leading-tight text-gray-900 dark:text-white">Customer email replies</h3>
@@ -425,8 +425,8 @@
 
 			<ScrollReveal delay={150}>
 				<div class="glass-card flex h-full min-h-[132px] items-start gap-4 rounded-xl p-5">
-					<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
-						<i class="fas fa-list-check text-blue-500"></i>
+					<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-teal-500/10">
+						<i class="fas fa-list-check text-teal-500"></i>
 					</div>
 					<div class="flex min-h-full flex-1 flex-col">
 						<h3 class="min-h-[3rem] font-semibold leading-tight text-gray-900 dark:text-white">Meeting notes to action items</h3>
@@ -437,8 +437,8 @@
 
 			<ScrollReveal delay={200}>
 				<div class="glass-card flex h-full min-h-[132px] items-start gap-4 rounded-xl p-5">
-					<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
-						<i class="fas fa-chart-bar text-blue-500"></i>
+					<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-teal-500/10">
+						<i class="fas fa-chart-bar text-teal-500"></i>
 					</div>
 					<div class="flex min-h-full flex-1 flex-col">
 						<h3 class="min-h-[3rem] font-semibold leading-tight text-gray-900 dark:text-white">Weekly reports</h3>
@@ -473,8 +473,8 @@
 
 			<ScrollReveal delay={350}>
 				<div class="glass-card flex h-full min-h-[132px] items-start gap-4 rounded-xl p-5">
-					<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-blue-500/10">
-						<i class="fas fa-file-contract text-blue-500"></i>
+					<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-teal-500/10">
+						<i class="fas fa-file-contract text-teal-500"></i>
 					</div>
 					<div class="flex min-h-full flex-1 flex-col">
 						<h3 class="min-h-[3rem] font-semibold leading-tight text-gray-900 dark:text-white">Public document summaries</h3>
@@ -505,11 +505,11 @@
 			<div class="glass-card rounded-2xl p-6 md:p-8">
 				<ul class="space-y-4">
 					<li class="flex items-start gap-3">
-						<i class="fas fa-circle-check mt-0.5 text-sm text-blue-400"></i>
+						<i class="fas fa-circle-check mt-0.5 text-sm text-teal-400"></i>
 						<span class="text-gray-700 dark:text-gray-300">A summary of your workflow as I understand it</span>
 					</li>
 					<li class="flex items-start gap-3">
-						<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+						<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 						<span class="text-gray-700 dark:text-gray-300">Where AI might realistically help</span>
 					</li>
 					<li class="flex items-start gap-3">
@@ -517,11 +517,11 @@
 						<span class="text-gray-700 dark:text-gray-300">Where AI should not be used</span>
 					</li>
 					<li class="flex items-start gap-3">
-						<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+						<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 						<span class="text-gray-700 dark:text-gray-300">Suggested prompts or templates you can try</span>
 					</li>
 					<li class="flex items-start gap-3">
-						<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+						<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 						<span class="text-gray-700 dark:text-gray-300">Simple tool suggestions (if relevant)</span>
 					</li>
 					<li class="flex items-start gap-3">
@@ -529,7 +529,7 @@
 						<span class="text-gray-700 dark:text-gray-300">Risks and guardrails to keep in mind</span>
 					</li>
 					<li class="flex items-start gap-3">
-						<i class="fas fa-circle-check mt-0.5 text-sm text-blue-500"></i>
+						<i class="fas fa-circle-check mt-0.5 text-sm text-teal-500"></i>
 						<span class="text-gray-700 dark:text-gray-300">A small test plan or next steps</span>
 					</li>
 				</ul>
@@ -650,8 +650,8 @@
 	<div class="mx-auto max-w-3xl px-4 sm:px-6">
 		<ScrollReveal>
 			<div class="flex flex-col items-center gap-6 md:flex-row md:items-start">
-				<div class="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-blue-500/10 border border-blue-500/20">
-					<i class="fas fa-user text-2xl text-blue-400"></i>
+				<div class="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-teal-500/10 border border-teal-500/20">
+					<i class="fas fa-user text-2xl text-teal-400"></i>
 				</div>
 				<div>
 					<h2 class="mb-3 font-serif text-xl font-semibold text-gray-900 dark:text-white">About me</h2>
@@ -696,7 +696,7 @@
 						id="name"
 						bind:value={formData.name}
 						required
-						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
 						placeholder="Your name"
 					/>
 				</div>
@@ -708,7 +708,7 @@
 						id="email"
 						bind:value={formData.email}
 						required
-						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
 						placeholder="you@example.com"
 					/>
 				</div>
@@ -720,7 +720,7 @@
 						bind:value={formData.workflow}
 						required
 						rows="3"
-						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
 						placeholder="e.g. I reply to 20+ similar customer emails each day about shipping status"
 					></textarea>
 				</div>
@@ -731,7 +731,7 @@
 						id="currentProcess"
 						bind:value={formData.currentProcess}
 						rows="3"
-						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
 						placeholder="Walk through the steps you currently take"
 					></textarea>
 				</div>
@@ -742,7 +742,7 @@
 						type="text"
 						id="tools"
 						bind:value={formData.tools}
-						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
 						placeholder="e.g. Gmail, Google Docs, Slack, Notion"
 					/>
 				</div>
@@ -753,7 +753,7 @@
 						id="betterLooksLike"
 						bind:value={formData.betterLooksLike}
 						rows="2"
-						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
 						placeholder="e.g. Spend less time writing the same thing, fewer errors, faster turnaround"
 					></textarea>
 				</div>
@@ -762,11 +762,11 @@
 					<legend class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">Can I quote or summarize this workflow anonymously in future writing?</legend>
 					<div class="flex gap-4">
 						<label class="flex min-h-[44px] items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
-							<input type="radio" bind:group={formData.quotePermission} value="yes" class="accent-blue-500 h-5 w-5" />
+							<input type="radio" bind:group={formData.quotePermission} value="yes" class="accent-teal-500 h-5 w-5" />
 							Yes
 						</label>
 						<label class="flex min-h-[44px] items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer">
-							<input type="radio" bind:group={formData.quotePermission} value="no" class="accent-blue-500 h-5 w-5" />
+							<input type="radio" bind:group={formData.quotePermission} value="no" class="accent-teal-500 h-5 w-5" />
 							No
 						</label>
 					</div>
@@ -778,7 +778,7 @@
 						id="sensitiveData"
 						bind:value={formData.sensitiveData}
 						rows="2"
-						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="w-full rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-gray-900 px-4 py-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 transition focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
 						placeholder="If yes, please anonymize before sending. Describe the type of data without including actual records."
 					></textarea>
 				</div>
@@ -786,7 +786,7 @@
 				<button
 					type="submit"
 					disabled={formStatus === 'sending'}
-					class="w-full rounded-lg bg-blue-600 px-6 py-3 text-sm font-medium text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 dark:focus:ring-offset-gray-950"
+					class="w-full rounded-lg bg-teal-600 px-6 py-3 text-sm font-medium text-white transition hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 disabled:opacity-50 dark:focus:ring-offset-gray-950"
 				>
 					{#if formStatus === 'sending'}
 						Preparing...
@@ -798,7 +798,7 @@
 				</button>
 
 				{#if formStatus === 'sent'}
-					<p class="text-center text-sm text-blue-500">
+					<p class="text-center text-sm text-teal-500">
 						Your email client should open with the details pre-filled. If it did not, you can email me directly at me@hongincanada.com.
 					</p>
 				{/if}

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import { recentPosts, formatPostDate } from '$lib/data/blogPosts';
+
+	const canonical = 'https://www.hongincanada.com/blog';
+	const title = 'Writing — Blog | Hong in Canada';
+	const description =
+		'Essays and field notes on building AI-powered products from 0 to 1: agentic workflows, product design, and lessons from shipping software fast.';
+	const ogImage = 'https://www.hongincanada.com/profile.png';
+
+	const blogSchema = JSON.stringify({
+		'@context': 'https://schema.org',
+		'@type': 'Blog',
+		name: 'Hong in Canada — Writing',
+		description,
+		url: canonical,
+		author: { '@type': 'Person', name: 'Hong', url: 'https://www.hongincanada.com' },
+		blogPost: recentPosts.map((p) => ({
+			'@type': 'BlogPosting',
+			headline: p.title,
+			description: p.description,
+			datePublished: p.date,
+			url: 'https://www.hongincanada.com/blog/' + p.slug
+		}))
+	});
+</script>
+
+<svelte:head>
+	<title>{title}</title>
+	<meta name="description" content={description} />
+	<link rel="canonical" href={canonical} />
+
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content={title} />
+	<meta property="og:description" content={description} />
+	<meta property="og:url" content={canonical} />
+	<meta property="og:image" content={ogImage} />
+
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={title} />
+	<meta name="twitter:description" content={description} />
+	<meta name="twitter:image" content={ogImage} />
+
+	{@html '<script type="application/ld+json">' + blogSchema + '<' + '/script>'}
+</svelte:head>
+
+<section class="py-16 sm:py-20" style="background: var(--bg);">
+	<div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+		<!-- Breadcrumb -->
+		<nav class="mono-label mb-8 flex items-center gap-2" aria-label="Breadcrumb">
+			<a href="/" class="transition-colors hover:text-[var(--accent)]">Home</a>
+			<span aria-hidden="true">/</span>
+			<span style="color: var(--muted);">Writing</span>
+		</nav>
+
+		<header class="mb-12 max-w-2xl">
+			<p class="eyebrow mb-3">Writing</p>
+			<h1 class="font-serif text-4xl font-medium md:text-5xl" style="color: var(--text);">
+				Notes on building with AI
+			</h1>
+			<p class="mt-4 text-lg leading-relaxed" style="color: var(--muted);">
+				{description}
+			</p>
+		</header>
+
+		<div class="grid gap-5 sm:grid-cols-2">
+			{#each recentPosts as post (post.slug)}
+				<article class="h-full">
+					<a
+						href={'/blog/' + post.slug}
+						class="glass-card group flex h-full flex-col rounded-2xl p-6"
+					>
+						<div class="mb-4 flex items-center gap-3">
+							<div
+								class="flex h-10 w-10 items-center justify-center rounded-lg"
+								style="background: var(--accent-soft); color: var(--accent);"
+							>
+								<i class="fas {post.icon}" aria-hidden="true"></i>
+							</div>
+							<time class="mono-label" datetime={post.date}>{formatPostDate(post.date)}</time>
+						</div>
+						<h2
+							class="mb-2 font-serif text-xl font-semibold leading-snug transition group-hover:text-[var(--accent)]"
+							style="color: var(--text);"
+						>
+							{post.title}
+						</h2>
+						<p class="mb-4 flex-1 text-sm leading-relaxed" style="color: var(--muted);">
+							{post.description}
+						</p>
+						<span
+							class="inline-flex items-center gap-2 text-sm font-medium transition group-hover:gap-3"
+							style="color: var(--accent);"
+						>
+							Read post <i class="fas fa-arrow-right text-xs" aria-hidden="true"></i>
+						</span>
+					</a>
+				</article>
+			{/each}
+		</div>
+	</div>
+</section>

--- a/src/routes/blog/app-flow-first-pilot/+page.svelte
+++ b/src/routes/blog/app-flow-first-pilot/+page.svelte
@@ -118,7 +118,7 @@
 					onclick={() => (showTOC = !showTOC)}
 					class="flex items-center gap-2 min-h-[44px] rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
 				>
-					<i class="fas fa-list text-xs text-blue-500" aria-hidden="true"></i>
+					<i class="fas fa-list text-xs text-teal-500" aria-hidden="true"></i>
 					<span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Contents</span>
 					<i class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-xs text-gray-400" aria-hidden="true"></i>
 				</button>
@@ -149,7 +149,7 @@
 				<span class="text-gray-600 dark:text-gray-300">App Flow: First Pilot</span>
 			</nav>
 			<div class="mb-4 flex items-center gap-3">
-				<span class="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-500 dark:text-blue-400">
+				<span class="rounded-full bg-teal-500/10 px-3 py-1 text-xs font-medium text-teal-500 dark:text-teal-400">
 					<i class="fas fa-link mr-1.5" aria-hidden="true"></i>MiniBreaks
 				</span>
 				<span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
@@ -178,14 +178,14 @@
 								class="prose prose-lg max-w-none dark:prose-invert
 									prose-headings:font-bold prose-headings:text-gray-900 dark:prose-headings:text-white
 									prose-h2:mt-12 prose-h2:mb-5 prose-h2:text-2xl prose-h2:scroll-mt-24
-									prose-h3:mt-8 prose-h3:mb-4 prose-h3:text-xl prose-h3:text-blue-700 dark:prose-h3:text-blue-400
+									prose-h3:mt-8 prose-h3:mb-4 prose-h3:text-xl prose-h3:text-teal-700 dark:prose-h3:text-teal-400
 									prose-p:leading-relaxed prose-p:text-gray-700 dark:prose-p:text-gray-300
 									prose-li:mb-2 prose-li:text-gray-700 dark:prose-li:text-gray-300
 									prose-ul:list-disc prose-ul:list-outside prose-ul:pl-6 prose-ol:list-decimal prose-ol:list-outside prose-ol:pl-6
 									prose-li:marker:text-gray-500 dark:prose-li:marker:text-gray-400
 									prose-strong:text-gray-900 dark:prose-strong:text-white
-									prose-a:text-blue-600 prose-a:underline-offset-2 dark:prose-a:text-blue-400
-									prose-blockquote:border-blue-500 prose-blockquote:text-gray-700 dark:prose-blockquote:text-gray-300
+									prose-a:text-teal-600 prose-a:underline-offset-2 dark:prose-a:text-teal-400
+									prose-blockquote:border-teal-500 prose-blockquote:text-gray-700 dark:prose-blockquote:text-gray-300
 									[&_section]:scroll-mt-24 [&_h2]:scroll-mt-24"
 							>
 								<section id="from-mosaic-to-pilot">
@@ -203,7 +203,7 @@
 										I am experimenting with a simple principle: build <strong>disposable micro-apps</strong> that each do one thing well, and let users chain them when they need a longer workflow.
 									</p>
 
-									<div class="not-prose my-8 rounded-r-xl border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+									<div class="not-prose my-8 rounded-r-xl border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
 										<p class="mb-2 leading-relaxed text-gray-700 dark:text-gray-300">
 											<strong>Reference:</strong> The foundational concept is documented in <a href="https://minibreaks.io/about/app-chaining" target="_blank" rel="noopener noreferrer">App Chaining on MiniBreaks</a>.
 										</p>
@@ -454,7 +454,7 @@
 										<li>
 											<a
 												href={`#${item.id}`}
-												class="block text-gray-600 transition-colors hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+												class="block text-gray-600 transition-colors hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
 											>
 												{item.title}
 											</a>
@@ -468,9 +468,9 @@
 									Open Apps
 								</p>
 								<div class="space-y-2 text-sm">
-									<a class="block text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300" href="https://minibreaks.io/apps/squad-shuffle" target="_blank" rel="noopener noreferrer">Squad Shuffer</a>
-									<a class="block text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300" href="https://minibreaks.io/apps/group-qualifier" target="_blank" rel="noopener noreferrer">Group Qualifier</a>
-									<a class="block text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300" href="https://minibreaks.io/apps/tournament-bracket-builder" target="_blank" rel="noopener noreferrer">Tournament Bracket</a>
+									<a class="block text-teal-600 transition-colors hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300" href="https://minibreaks.io/apps/squad-shuffle" target="_blank" rel="noopener noreferrer">Squad Shuffer</a>
+									<a class="block text-teal-600 transition-colors hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300" href="https://minibreaks.io/apps/group-qualifier" target="_blank" rel="noopener noreferrer">Group Qualifier</a>
+									<a class="block text-teal-600 transition-colors hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300" href="https://minibreaks.io/apps/tournament-bracket-builder" target="_blank" rel="noopener noreferrer">Tournament Bracket</a>
 								</div>
 							</div>
 
@@ -484,7 +484,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on Twitter"
-										class="flex-1 rounded-lg bg-blue-50 p-2 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+										class="flex-1 rounded-lg bg-teal-50 p-2 text-center text-sm font-medium text-teal-600 transition-colors hover:bg-teal-100 dark:bg-teal-900/30 dark:text-teal-400 dark:hover:bg-teal-900/50"
 									>
 										<i class="fab fa-twitter text-xs"></i>
 									</a>
@@ -493,7 +493,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on LinkedIn"
-										class="flex-1 rounded-lg bg-blue-50 p-2 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+										class="flex-1 rounded-lg bg-teal-50 p-2 text-center text-sm font-medium text-teal-600 transition-colors hover:bg-teal-100 dark:bg-teal-900/30 dark:text-teal-400 dark:hover:bg-teal-900/50"
 									>
 										<i class="fab fa-linkedin-in text-xs"></i>
 									</a>
@@ -521,7 +521,7 @@
 	{#if showBackToTop}
 		<button
 			onclick={scrollToTop}
-			class="fixed bottom-8 right-8 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-blue-500 text-white shadow-lg transition-colors hover:bg-blue-600"
+			class="fixed bottom-8 right-8 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-teal-500 text-white shadow-lg transition-colors hover:bg-teal-600"
 			aria-label="Back to top"
 		>
 			<i class="fas fa-arrow-up text-sm" aria-hidden="true"></i>

--- a/src/routes/blog/building-deckmark/+page.svelte
+++ b/src/routes/blog/building-deckmark/+page.svelte
@@ -226,7 +226,7 @@
 					onclick={() => (showTOC = !showTOC)}
 					class="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
 				>
-					<i class="fas fa-list text-blue-500 text-xs" aria-hidden="true"></i>
+					<i class="fas fa-list text-teal-500 text-xs" aria-hidden="true"></i>
 					<span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Contents</span>
 					<i
 						class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-gray-400 text-xs"
@@ -261,7 +261,7 @@
 			</nav>
 			<div class="mb-4 flex items-center gap-3">
 				<span
-					class="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-600 dark:text-blue-400"
+					class="rounded-full bg-teal-500/10 px-3 py-1 text-xs font-medium text-teal-600 dark:text-teal-400"
 				>
 					<i class="fas fa-wand-magic-sparkles mr-1.5" aria-hidden="true"></i>Deckmark
 				</span>
@@ -294,7 +294,7 @@
 					href="https://github.com/sowenzhang/deckmark"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="text-blue-600 dark:text-blue-400 hover:underline"
+					class="text-teal-600 dark:text-teal-400 hover:underline"
 				>
 					<i class="fab fa-github mr-1.5" aria-hidden="true"></i>github.com/sowenzhang/deckmark
 				</a>
@@ -320,17 +320,17 @@
 								prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-p:leading-relaxed
 								prose-li:text-gray-700 dark:prose-li:text-gray-300 prose-li:mb-2
 								prose-strong:text-gray-900 dark:prose-strong:text-white
-								prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:underline-offset-2
-								prose-code:text-blue-700 dark:prose-code:text-blue-300 prose-code:bg-blue-50 dark:prose-code:bg-blue-950/40 prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:font-medium prose-code:before:content-none prose-code:after:content-none
+								prose-a:text-teal-600 dark:prose-a:text-teal-400 prose-a:underline-offset-2
+								prose-code:text-teal-700 dark:prose-code:text-teal-300 prose-code:bg-teal-50 dark:prose-code:bg-teal-950/40 prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:font-medium prose-code:before:content-none prose-code:after:content-none
 								[&_section]:scroll-mt-24 [&_h2]:scroll-mt-24"
 							>
 								<section id="tldr">
-									<div class="not-prose mb-8 rounded-xl border border-blue-200 dark:border-blue-800/60 bg-blue-50/70 dark:bg-blue-950/30 px-6 py-5">
-										<p class="mb-2 text-xs font-bold uppercase tracking-widest text-blue-600 dark:text-blue-400">
+									<div class="not-prose mb-8 rounded-xl border border-teal-200 dark:border-teal-800/60 bg-teal-50/70 dark:bg-teal-950/30 px-6 py-5">
+										<p class="mb-2 text-xs font-bold uppercase tracking-widest text-teal-600 dark:text-teal-400">
 											TL;DR
 										</p>
 										<p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-											<a href="https://github.com/sowenzhang/deckmark" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 font-semibold hover:underline">Deckmark</a>
+											<a href="https://github.com/sowenzhang/deckmark" target="_blank" rel="noopener noreferrer" class="text-teal-600 dark:text-teal-400 font-semibold hover:underline">Deckmark</a>
 											is an open-source MCP server that lets an AI agent generate a slide deck, open it in your browser, collect annotations you click directly on slide elements, then read those annotations back and apply the changes. No screenshots, no copy-paste, no "the third bullet on slide 4." It is also my bet on a pattern I think matters way beyond slides: tight human-in-the-loop review for agentic work.
 										</p>
 									</div>
@@ -351,8 +351,8 @@
 										This is the part that breaks the loop. You are doing all the work of seeing the slide and the agent is doing none of it. By the time you finish typing the third correction, you have basically given up on review and accepted whatever is there.
 									</p>
 
-									<div class="not-prose my-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 px-5 py-4">
-										<p class="text-sm font-semibold text-blue-700 dark:text-blue-400 mb-1">
+									<div class="not-prose my-6 rounded-lg border-l-4 border-teal-500 bg-teal-50 dark:bg-teal-900/20 px-5 py-4">
+										<p class="text-sm font-semibold text-teal-700 dark:text-teal-400 mb-1">
 											<i class="fas fa-lightbulb mr-1.5" aria-hidden="true"></i>The friction
 										</p>
 										<p class="text-gray-700 dark:text-gray-300 text-base">
@@ -599,8 +599,8 @@
 										Building Deckmark was a way to think this through in code, not in a deck about decks. It made me much more concrete about how agent workflows, browser-based UX, and developer workflows can actually fit together. It also gave me a thing I use myself, which is the only honest test for whether a tool is good.
 									</p>
 
-									<div class="not-prose my-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 px-5 py-4">
-										<p class="text-sm font-semibold text-blue-700 dark:text-blue-400 mb-1">
+									<div class="not-prose my-6 rounded-lg border-l-4 border-teal-500 bg-teal-50 dark:bg-teal-900/20 px-5 py-4">
+										<p class="text-sm font-semibold text-teal-700 dark:text-teal-400 mb-1">
 											<i class="fas fa-compass mr-1.5" aria-hidden="true"></i>The bet
 										</p>
 										<p class="text-gray-700 dark:text-gray-300 text-base">
@@ -686,7 +686,7 @@
 									{#each tableOfContents as item (item.id)}
 										<a
 											href="#{item.id}"
-											class="block rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+											class="block rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-teal-50 dark:hover:bg-teal-900/20 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
 										>
 											{item.title}
 										</a>
@@ -708,7 +708,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on Twitter"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-twitter text-xs"></i>
 									</a>
@@ -717,7 +717,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on LinkedIn"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-linkedin-in text-xs"></i>
 									</a>
@@ -738,10 +738,10 @@
 							</div>
 
 							<div
-								class="rounded-xl border border-blue-200 dark:border-blue-800/60 bg-blue-50/70 dark:bg-blue-950/30 p-5"
+								class="rounded-xl border border-teal-200 dark:border-teal-800/60 bg-teal-50/70 dark:bg-teal-950/30 p-5"
 							>
 								<h3
-									class="mb-3 text-xs font-bold uppercase tracking-widest text-blue-600 dark:text-blue-400"
+									class="mb-3 text-xs font-bold uppercase tracking-widest text-teal-600 dark:text-teal-400"
 								>
 									The Repo
 								</h3>
@@ -749,7 +749,7 @@
 									href="https://github.com/sowenzhang/deckmark"
 									target="_blank"
 									rel="noopener noreferrer"
-									class="flex items-center gap-2 text-sm font-medium text-gray-800 dark:text-gray-200 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+									class="flex items-center gap-2 text-sm font-medium text-gray-800 dark:text-gray-200 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
 								>
 									<i class="fab fa-github" aria-hidden="true"></i>
 									sowenzhang/deckmark

--- a/src/routes/blog/introducing-crossit/+page.svelte
+++ b/src/routes/blog/introducing-crossit/+page.svelte
@@ -130,7 +130,7 @@
 					onclick={() => (showTOC = !showTOC)}
 					class="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
 				>
-					<i class="fas fa-list text-blue-500 text-xs" aria-hidden="true"></i>
+					<i class="fas fa-list text-teal-500 text-xs" aria-hidden="true"></i>
 					<span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Contents</span>
 					<i class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-gray-400 text-xs" aria-hidden="true"></i>
 				</button>
@@ -161,7 +161,7 @@
 				<span class="text-gray-600 dark:text-gray-300">Introducing CrossIt</span>
 			</nav>
 			<div class="mb-4 flex items-center gap-3">
-				<span class="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-600 dark:text-blue-400">
+				<span class="rounded-full bg-teal-500/10 px-3 py-1 text-xs font-medium text-teal-600 dark:text-teal-400">
 					<i class="fas fa-check-double mr-1.5" aria-hidden="true"></i>CrossIt
 				</span>
 				<span class="rounded-full bg-gray-100 dark:bg-gray-800 px-3 py-1 text-xs font-medium text-gray-500 dark:text-gray-400">
@@ -194,7 +194,7 @@
 								prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-p:leading-relaxed
 								prose-li:text-gray-700 dark:prose-li:text-gray-300 prose-li:mb-2
 								prose-strong:text-gray-900 dark:prose-strong:text-white
-								prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:underline-offset-2
+								prose-a:text-teal-600 dark:prose-a:text-teal-400 prose-a:underline-offset-2
 								[&_section]:scroll-mt-24 [&_h2]:scroll-mt-24">
 
 								<p>
@@ -383,7 +383,7 @@
 									{#each tableOfContents as item (item.id)}
 										<a
 											href="#{item.id}"
-											class="block rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+											class="block rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-teal-50 dark:hover:bg-teal-900/20 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
 										>
 											{item.title}
 										</a>
@@ -399,7 +399,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on Twitter"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-twitter text-xs"></i>
 									</a>
@@ -408,7 +408,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on LinkedIn"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-linkedin-in text-xs"></i>
 									</a>

--- a/src/routes/blog/loop-engineering/+page.svelte
+++ b/src/routes/blog/loop-engineering/+page.svelte
@@ -113,7 +113,7 @@
 					<i class="fas fa-arrow-left text-xs" aria-hidden="true"></i> Hong in Canada
 				</a>
 				<button onclick={() => (showTOC = !showTOC)} class="flex items-center gap-2 min-h-[44px] rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700">
-					<i class="fas fa-list text-xs text-blue-500" aria-hidden="true"></i>
+					<i class="fas fa-list text-xs text-teal-500" aria-hidden="true"></i>
 					<span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Contents</span>
 					<i class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-xs text-gray-400" aria-hidden="true"></i>
 				</button>
@@ -136,7 +136,7 @@
 				<i class="fas fa-chevron-right text-[9px]" aria-hidden="true"></i><span class="text-gray-600 dark:text-gray-300">Loop Engineering</span>
 			</nav>
 			<div class="mb-4 flex flex-wrap items-center gap-3">
-				<span class="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-600 dark:text-blue-400"><i class="fas fa-arrows-rotate mr-1.5" aria-hidden="true"></i>Spiderloop</span>
+				<span class="rounded-full bg-teal-500/10 px-3 py-1 text-xs font-medium text-teal-600 dark:text-teal-400"><i class="fas fa-arrows-rotate mr-1.5" aria-hidden="true"></i>Spiderloop</span>
 				<span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">Agentic Engineering</span>
 			</div>
 			<h1 class="mb-5 font-serif text-4xl font-semibold leading-tight text-gray-900 dark:text-white md:text-5xl">Loop Engineering: Building Web Apps with an Agent in the Loop</h1>
@@ -155,9 +155,9 @@
 				<article class="min-w-0 flex-1">
 					<div class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900">
 									<div class="p-5 sm:p-8 lg:p-14">
-							<div class="prose prose-lg max-w-none dark:prose-invert prose-headings:font-bold prose-headings:text-gray-900 dark:prose-headings:text-white prose-h2:mb-5 prose-h2:mt-12 prose-h2:scroll-mt-24 prose-h3:mb-3 prose-h3:mt-8 prose-h3:scroll-mt-24 prose-p:leading-relaxed prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-li:text-gray-700 dark:prose-li:text-gray-300 prose-strong:text-gray-900 dark:prose-strong:text-white prose-a:text-blue-700 dark:prose-a:text-blue-400 prose-code:rounded prose-code:bg-blue-50 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-blue-800 prose-code:before:content-none prose-code:after:content-none dark:prose-code:bg-blue-950/40 dark:prose-code:text-blue-300">
+							<div class="prose prose-lg max-w-none dark:prose-invert prose-headings:font-bold prose-headings:text-gray-900 dark:prose-headings:text-white prose-h2:mb-5 prose-h2:mt-12 prose-h2:scroll-mt-24 prose-h3:mb-3 prose-h3:mt-8 prose-h3:scroll-mt-24 prose-p:leading-relaxed prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-li:text-gray-700 dark:prose-li:text-gray-300 prose-strong:text-gray-900 dark:prose-strong:text-white prose-a:text-teal-700 dark:prose-a:text-teal-400 prose-code:rounded prose-code:bg-teal-50 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-teal-800 prose-code:before:content-none prose-code:after:content-none dark:prose-code:bg-teal-950/40 dark:prose-code:text-teal-300">
 								<section id="tldr">
-																<div class="not-prose mb-8 rounded-xl border border-blue-200 bg-blue-50/80 px-6 py-5 dark:border-blue-800/60 dark:bg-blue-950/30">
+																<div class="not-prose mb-8 rounded-xl border border-teal-200 bg-teal-50/80 px-6 py-5 dark:border-teal-800/60 dark:bg-teal-950/30">
 																	<p class="!m-0 leading-relaxed text-gray-700 dark:text-gray-300">One-shot generation produces a plausible v1 and then stops. Spiderloop wraps the agent in a governed loop: build, observe reality in a real browser, run objective gates, iterate, and stop honestly when the evidence says it is done. I call the discipline behind that loop <strong>Loop Engineering</strong>.</p>
 									</div>
 								</section>
@@ -165,7 +165,7 @@
 								<section id="what-is-a-harness">
 									<h2>What Is an Agentic Harness?</h2>
 									<p>An AI agent can write code, operate tools, and make decisions. An <strong>agentic harness</strong> is the system around that agent: it gives the work a shape, observes what actually happened, runs checks, feeds useful failures back, and decides whether to continue or stop.</p>
-									<div class="not-prose my-8 rounded-xl border border-blue-200 bg-blue-50 px-6 py-5 dark:border-blue-800/60 dark:bg-blue-950/30"><p class="!m-0 text-gray-700 dark:text-gray-300">The harness does not replace the agent. It turns a one-off prompt into a repeatable workflow with boundaries, evidence, and memory.</p></div>
+									<div class="not-prose my-8 rounded-xl border border-teal-200 bg-teal-50 px-6 py-5 dark:border-teal-800/60 dark:bg-teal-950/30"><p class="!m-0 text-gray-700 dark:text-gray-300">The harness does not replace the agent. It turns a one-off prompt into a repeatable workflow with boundaries, evidence, and memory.</p></div>
 									<p>Spiderloop is one implementation of that idea. Its source is organized around a domain-agnostic core, web workflows, and a service layer. The examples below are more useful than a tour of every internal module:</p>
 									<ul>
 										<li><strong><code>/spiderloop:run</code>:</strong> build a site, inspect it in a real browser, run quality gates, then iterate.</li>
@@ -184,7 +184,7 @@
 									<p>Give an agent a brief that says “build me a site” and it can produce something convincing in minutes. The page loads. The headline is there. The colors are coherent. Everyone nods.</p>
 									<p>Then you look closer. A social card points to an image that does not exist. A block of useful content is hidden from assistive technology. A mobile layout overflows by 12 pixels. The agent did not lie exactly; it simply had no mechanism that forced it to find out.</p>
 									<p>That is the failure mode I care about. The problem is not that the model cannot make a good first attempt. The problem is that the thing doing the work is also being asked to decide whether the work is good.</p>
-																<div class="not-prose my-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 px-5 py-4 dark:bg-blue-950/30"><p class="mb-1 text-sm font-semibold text-blue-700 dark:text-blue-400"><i class="fas fa-arrow-right mr-1.5" aria-hidden="true"></i>The reframe</p><p class="!m-0 text-gray-700 dark:text-gray-300">Do not optimize for a perfect generation. Build a system that can produce evidence, respond to it, and know when to stop.</p></div>
+																<div class="not-prose my-6 rounded-lg border-l-4 border-teal-500 bg-teal-50 px-5 py-4 dark:bg-teal-950/30"><p class="mb-1 text-sm font-semibold text-teal-700 dark:text-teal-400"><i class="fas fa-arrow-right mr-1.5" aria-hidden="true"></i>The reframe</p><p class="!m-0 text-gray-700 dark:text-gray-300">Do not optimize for a perfect generation. Build a system that can produce evidence, respond to it, and know when to stop.</p></div>
 								</section>
 
 								<section id="separation-of-powers">
@@ -226,7 +226,7 @@ report(state)</code></pre>
 										<table class="min-w-[680px] w-full border-collapse text-left text-sm">
 											<caption class="sr-only">Separate quality evidence for the Spiderloop and single-pass runs</caption>
 											<thead class="bg-gray-50 text-xs uppercase tracking-wider text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-												<tr><th scope="col" class="px-4 py-3 font-semibold">Signal</th><th scope="col" class="px-4 py-3 font-semibold text-blue-700 dark:text-blue-400">Spiderloop run</th><th scope="col" class="px-4 py-3 font-semibold text-blue-700 dark:text-blue-400">Single-pass run</th></tr>
+												<tr><th scope="col" class="px-4 py-3 font-semibold">Signal</th><th scope="col" class="px-4 py-3 font-semibold text-teal-700 dark:text-teal-400">Spiderloop run</th><th scope="col" class="px-4 py-3 font-semibold text-teal-700 dark:text-teal-400">Single-pass run</th></tr>
 											</thead>
 											<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
 												<tr><th scope="row" class="px-4 py-4 font-semibold text-gray-800 dark:text-gray-200">Routes checked</th><td class="px-4 py-4 text-gray-700 dark:text-gray-300">6 / 6, all gates complete</td><td class="px-4 py-4 text-gray-700 dark:text-gray-300">6 / 6 loaded in the live audit</td></tr>
@@ -280,13 +280,13 @@ report(state)</code></pre>
 									<h2>Build for the Loop, Not the Prompt</h2>
 									<p>The model is still the interesting part when it makes a surprising design choice or solves a hard implementation detail. But the durable engineering insight is elsewhere: generation is only one state in a larger system.</p>
 									<p><strong>Loop Engineering means build, verify against objective truth, iterate, and know when to stop.</strong> The model supplies capability. The harness supplies boundaries, evidence, and memory. A human still closes the last stretch where taste, context, and judgment matter.</p>
-																			<div class="not-prose my-8 rounded-xl border border-blue-200 bg-blue-50 px-6 py-5 dark:border-blue-800/60 dark:bg-blue-950/30"><p class="mb-1 text-sm font-semibold text-blue-700 dark:text-blue-400"><i class="fas fa-compass mr-1.5" aria-hidden="true"></i>The takeaway</p><p class="!m-0 text-gray-700 dark:text-gray-300">Do not ask your agent whether it is done. Give it a loop that can find out.</p></div>
+																			<div class="not-prose my-8 rounded-xl border border-teal-200 bg-teal-50 px-6 py-5 dark:border-teal-800/60 dark:bg-teal-950/30"><p class="mb-1 text-sm font-semibold text-teal-700 dark:text-teal-400"><i class="fas fa-compass mr-1.5" aria-hidden="true"></i>The takeaway</p><p class="!m-0 text-gray-700 dark:text-gray-300">Do not ask your agent whether it is done. Give it a loop that can find out.</p></div>
 								</section>
 							</div>
 
 							<div class="mt-12 flex flex-wrap items-center justify-between gap-4 border-t border-gray-200 pt-6 dark:border-gray-700">
-								<div class="flex items-center gap-3"><button onclick={copyLink} class="inline-flex items-center min-h-[44px] rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition hover:border-blue-400 hover:text-blue-600 dark:border-gray-700 dark:text-gray-300 dark:hover:text-blue-400" aria-label="Copy article link"><i class="fas fa-link mr-1.5" aria-hidden="true"></i>Share link</button>{#if copyStatus}<span class="text-sm text-blue-600 dark:text-blue-400">{copyStatus}</span>{/if}</div>
-								<a href={getLinkedInShareUrl()} target="_blank" rel="noopener noreferrer" class="inline-flex items-center min-h-[44px] text-sm font-medium text-blue-700 hover:underline dark:text-blue-400"><i class="fab fa-linkedin mr-1.5" aria-hidden="true"></i>Share on LinkedIn</a>
+								<div class="flex items-center gap-3"><button onclick={copyLink} class="inline-flex items-center min-h-[44px] rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition hover:border-teal-400 hover:text-teal-600 dark:border-gray-700 dark:text-gray-300 dark:hover:text-teal-400" aria-label="Copy article link"><i class="fas fa-link mr-1.5" aria-hidden="true"></i>Share link</button>{#if copyStatus}<span class="text-sm text-teal-600 dark:text-teal-400">{copyStatus}</span>{/if}</div>
+								<a href={getLinkedInShareUrl()} target="_blank" rel="noopener noreferrer" class="inline-flex items-center min-h-[44px] text-sm font-medium text-teal-700 hover:underline dark:text-teal-400"><i class="fab fa-linkedin mr-1.5" aria-hidden="true"></i>Share on LinkedIn</a>
 							</div>
 						</div>
 					</div>
@@ -294,7 +294,7 @@ report(state)</code></pre>
 
 				{#if showTOC}
 					<aside class="order-first h-fit shrink-0 lg:order-last lg:sticky lg:top-20 lg:w-64" aria-label="Table of contents">
-						<div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900"><p class="mb-4 text-xs font-bold uppercase tracking-widest text-blue-600 dark:text-blue-400">On this page</p><nav class="space-y-2">{#each tableOfContents as item}<a href={'#' + item.id} class="flex items-center min-h-[44px] text-sm text-gray-600 transition hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400">{item.title}</a>{/each}</nav></div>
+						<div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900"><p class="mb-4 text-xs font-bold uppercase tracking-widest text-teal-600 dark:text-teal-400">On this page</p><nav class="space-y-2">{#each tableOfContents as item}<a href={'#' + item.id} class="flex items-center min-h-[44px] text-sm text-gray-600 transition hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400">{item.title}</a>{/each}</nav></div>
 					</aside>
 				{/if}
 			</div>
@@ -304,6 +304,6 @@ report(state)</code></pre>
 	<MorePosts currentSlug="loop-engineering" />
 
 	{#if showBackToTop}
-		<button onclick={scrollToTop} class="fixed bottom-6 right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-blue-600 text-white shadow-lg transition hover:bg-blue-700" aria-label="Back to top"><i class="fas fa-arrow-up" aria-hidden="true"></i></button>
+		<button onclick={scrollToTop} class="fixed bottom-6 right-6 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-teal-600 text-white shadow-lg transition hover:bg-teal-700" aria-label="Back to top"><i class="fas fa-arrow-up" aria-hidden="true"></i></button>
 	{/if}
 </div>

--- a/src/routes/blog/minibreaks-pivot/+page.svelte
+++ b/src/routes/blog/minibreaks-pivot/+page.svelte
@@ -104,7 +104,7 @@
 					onclick={() => (showTOC = !showTOC)}
 					class="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
 				>
-					<i class="fas fa-list text-blue-500 text-xs" aria-hidden="true"></i>
+					<i class="fas fa-list text-teal-500 text-xs" aria-hidden="true"></i>
 					<span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Contents</span>
 					<i class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-gray-400 text-xs" aria-hidden="true"></i>
 				</button>
@@ -136,7 +136,7 @@
 				<span class="text-gray-600 dark:text-gray-300">MiniBreaks Pivot</span>
 			</nav>
 			<div class="mb-4 flex items-center gap-3">
-				<span class="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-500 dark:text-blue-400">
+				<span class="rounded-full bg-teal-500/10 px-3 py-1 text-xs font-medium text-teal-500 dark:text-teal-400">
 					<i class="fas fa-leaf mr-1.5" aria-hidden="true"></i>MiniBreaks
 				</span>
 				<span class="rounded-full bg-gray-100 dark:bg-gray-800 px-3 py-1 text-xs font-medium text-gray-500 dark:text-gray-400">
@@ -166,13 +166,13 @@
 							<div class="prose prose-lg dark:prose-invert max-w-none
 								prose-headings:font-bold prose-headings:text-gray-900 dark:prose-headings:text-white
 								prose-h2:text-2xl prose-h2:mt-12 prose-h2:mb-5 prose-h2:scroll-mt-24
-								prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-4 prose-h3:text-blue-700 dark:prose-h3:text-blue-400
+								prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-4 prose-h3:text-teal-700 dark:prose-h3:text-teal-400
 								prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-p:leading-relaxed
 								prose-li:text-gray-700 dark:prose-li:text-gray-300 prose-li:mb-2
 								prose-ul:list-disc prose-ul:list-inside prose-ul:pl-1 prose-ol:list-decimal prose-ol:list-inside prose-ol:pl-1
 								prose-li:marker:text-gray-500 dark:prose-li:marker:text-gray-400
 								prose-strong:text-gray-900 dark:prose-strong:text-white
-								prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:underline-offset-2
+								prose-a:text-teal-600 dark:prose-a:text-teal-400 prose-a:underline-offset-2
 								prose-pre:rounded-xl prose-pre:border prose-pre:border-gray-200 dark:prose-pre:border-gray-700
 								prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-pre:px-5 prose-pre:py-4 prose-pre:my-6
 								[&_section]:scroll-mt-24 [&_h2]:scroll-mt-24">
@@ -248,11 +248,11 @@
 										The new goal is straightforward: <strong>Ship one small app every week</strong>. After one year, the site will contain <strong>52 tiny apps</strong>.
 									</p>
 
-									<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20 rounded-r-xl">
+									<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20 rounded-r-xl">
 										<p class="mb-2 text-gray-700 dark:text-gray-300 leading-relaxed">
 											<strong>Before → After</strong>
 										</p>
-										<ul class="list-disc list-inside pl-1 space-y-2 text-gray-700 dark:text-gray-300 marker:text-blue-500">
+										<ul class="list-disc list-inside pl-1 space-y-2 text-gray-700 dark:text-gray-300 marker:text-teal-500">
 											<li><strong>Workplace wellness platform</strong> → Micro-app hub</li>
 											<li><strong>Topic-focused</strong> → Tool-focused</li>
 											<li><strong>Hard to decide what to build</strong> → Endless small ideas</li>
@@ -479,7 +479,7 @@ Checks:
 										<li>
 											<a
 												href="#{item.id}"
-												class="block text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+												class="block text-gray-600 dark:text-gray-400 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
 											>
 												{item.title}
 											</a>
@@ -499,7 +499,7 @@ Checks:
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on Twitter"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-twitter text-xs"></i>
 									</a>
@@ -508,7 +508,7 @@ Checks:
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on LinkedIn"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-linkedin-in text-xs"></i>
 									</a>
@@ -537,7 +537,7 @@ Checks:
 	{#if showBackToTop}
 		<button
 			onclick={scrollToTop}
-			class="fixed bottom-8 right-8 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-blue-500 text-white shadow-lg hover:bg-blue-600 transition-colors"
+			class="fixed bottom-8 right-8 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-teal-500 text-white shadow-lg hover:bg-teal-600 transition-colors"
 			aria-label="Back to top"
 		>
 			<i class="fas fa-arrow-up text-sm" aria-hidden="true"></i>

--- a/src/routes/blog/nearbygame-pivot/+page.svelte
+++ b/src/routes/blog/nearbygame-pivot/+page.svelte
@@ -120,7 +120,7 @@
 					onclick={() => (showTOC = !showTOC)}
 					class="flex items-center gap-2 min-h-[44px] rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
 				>
-					<i class="fas fa-list text-xs text-blue-500" aria-hidden="true"></i>
+					<i class="fas fa-list text-xs text-teal-500" aria-hidden="true"></i>
 					<span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Contents</span>
 					<i class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-xs text-gray-400" aria-hidden="true"></i>
 				</button>
@@ -151,7 +151,7 @@
 				<span class="text-gray-600 dark:text-gray-300">NearbyGame Pivot</span>
 			</nav>
 			<div class="mb-4 flex items-center gap-3">
-				<span class="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-500 dark:text-blue-400">
+				<span class="rounded-full bg-teal-500/10 px-3 py-1 text-xs font-medium text-teal-500 dark:text-teal-400">
 					<i class="fas fa-route mr-1.5" aria-hidden="true"></i>NearbyGame
 				</span>
 				<span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
@@ -182,14 +182,14 @@
 								class="prose prose-lg max-w-none dark:prose-invert
 									prose-headings:font-bold prose-headings:text-gray-900 dark:prose-headings:text-white
 									prose-h2:mt-12 prose-h2:mb-5 prose-h2:text-2xl prose-h2:scroll-mt-24
-									prose-h3:mt-8 prose-h3:mb-4 prose-h3:text-xl prose-h3:text-blue-700 dark:prose-h3:text-blue-400
+									prose-h3:mt-8 prose-h3:mb-4 prose-h3:text-xl prose-h3:text-teal-700 dark:prose-h3:text-teal-400
 									prose-p:leading-relaxed prose-p:text-gray-700 dark:prose-p:text-gray-300
 									prose-li:mb-2 prose-li:text-gray-700 dark:prose-li:text-gray-300
 									prose-ul:list-disc prose-ul:list-outside prose-ul:pl-6 prose-ol:list-decimal prose-ol:list-inside prose-ol:pl-1
 									prose-li:marker:text-gray-500 dark:prose-li:marker:text-gray-400
 									prose-strong:text-gray-900 dark:prose-strong:text-white
-									prose-a:text-blue-600 prose-a:underline-offset-2 dark:prose-a:text-blue-400
-									prose-blockquote:border-blue-500 prose-blockquote:text-gray-700 dark:prose-blockquote:text-gray-300
+									prose-a:text-teal-600 prose-a:underline-offset-2 dark:prose-a:text-teal-400
+									prose-blockquote:border-teal-500 prose-blockquote:text-gray-700 dark:prose-blockquote:text-gray-300
 									[&_section]:scroll-mt-24 [&_h2]:scroll-mt-24"
 							>
 								<p class="text-lg leading-relaxed">
@@ -319,11 +319,11 @@
 										The new idea removes most of that. You open the app, start walking, and occasionally encounter someone. Only then do you decide whether you want to interact.
 									</p>
 
-									<div class="not-prose my-8 rounded-r-xl border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+									<div class="not-prose my-8 rounded-r-xl border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
 										<p class="mb-2 leading-relaxed text-gray-700 dark:text-gray-300">
 											<strong>Old loop -> New loop</strong>
 										</p>
-										<ul class="list-outside list-disc space-y-2 pl-6 text-gray-700 marker:text-blue-500 dark:text-gray-300">
+										<ul class="list-outside list-disc space-y-2 pl-6 text-gray-700 marker:text-teal-500 dark:text-gray-300">
 											<li><strong>Plan first</strong> -> <strong>Experience first</strong></li>
 											<li><strong>Coordinate people</strong> -> <strong>Discover people naturally</strong></li>
 											<li><strong>Logistics-heavy</strong> -> <strong>Low-pressure and ambient</strong></li>
@@ -546,7 +546,7 @@
 										<li>
 											<a
 												href={`#${item.id}`}
-												class="block text-gray-600 transition-colors hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+												class="block text-gray-600 transition-colors hover:text-teal-600 dark:text-gray-400 dark:hover:text-teal-400"
 											>
 												{item.title}
 											</a>
@@ -565,7 +565,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on Twitter"
-										class="flex-1 rounded-lg bg-blue-50 p-2 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+										class="flex-1 rounded-lg bg-teal-50 p-2 text-center text-sm font-medium text-teal-600 transition-colors hover:bg-teal-100 dark:bg-teal-900/30 dark:text-teal-400 dark:hover:bg-teal-900/50"
 									>
 										<i class="fab fa-twitter text-xs"></i>
 									</a>
@@ -574,7 +574,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on LinkedIn"
-										class="flex-1 rounded-lg bg-blue-50 p-2 text-center text-sm font-medium text-blue-600 transition-colors hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:bg-blue-900/50"
+										class="flex-1 rounded-lg bg-teal-50 p-2 text-center text-sm font-medium text-teal-600 transition-colors hover:bg-teal-100 dark:bg-teal-900/30 dark:text-teal-400 dark:hover:bg-teal-900/50"
 									>
 										<i class="fab fa-linkedin-in text-xs"></i>
 									</a>
@@ -602,7 +602,7 @@
 	{#if showBackToTop}
 		<button
 			onclick={scrollToTop}
-			class="fixed bottom-8 right-8 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-blue-500 text-white shadow-lg transition-colors hover:bg-blue-600"
+			class="fixed bottom-8 right-8 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-teal-500 text-white shadow-lg transition-colors hover:bg-teal-600"
 			aria-label="Back to top"
 		>
 			<i class="fas fa-arrow-up text-sm" aria-hidden="true"></i>

--- a/src/routes/blog/nearbygame-what-i-learned/+page.svelte
+++ b/src/routes/blog/nearbygame-what-i-learned/+page.svelte
@@ -134,7 +134,7 @@
 					onclick={() => (showTOC = !showTOC)}
 					class="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
 				>
-					<i class="fas fa-list text-blue-500 text-xs" aria-hidden="true"></i>
+					<i class="fas fa-list text-teal-500 text-xs" aria-hidden="true"></i>
 					<span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Contents</span>
 					<i
 						class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-gray-400 text-xs"
@@ -169,7 +169,7 @@
 			</nav>
 			<div class="mb-4 flex items-center gap-3">
 				<span
-					class="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-600 dark:text-blue-400"
+					class="rounded-full bg-teal-500/10 px-3 py-1 text-xs font-medium text-teal-600 dark:text-teal-400"
 				>
 					<i class="fas fa-route mr-1.5" aria-hidden="true"></i>NearbyGame
 				</span>
@@ -214,7 +214,7 @@
 								prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-p:leading-relaxed
 								prose-li:text-gray-700 dark:prose-li:text-gray-300 prose-li:mb-2
 								prose-strong:text-gray-900 dark:prose-strong:text-white
-								prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:underline-offset-2
+								prose-a:text-teal-600 dark:prose-a:text-teal-400 prose-a:underline-offset-2
 								[&_section]:scroll-mt-24 [&_h2]:scroll-mt-24"
 							>
 								<section id="hook">
@@ -233,8 +233,8 @@
 										-- into the walking game it is today.
 									</p>
 
-									<div class="not-prose my-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 px-5 py-4">
-										<p class="text-sm font-semibold text-blue-700 dark:text-blue-400 mb-1">
+									<div class="not-prose my-6 rounded-lg border-l-4 border-teal-500 bg-teal-50 dark:bg-teal-900/20 px-5 py-4">
+										<p class="text-sm font-semibold text-teal-700 dark:text-teal-400 mb-1">
 											<i class="fas fa-lightbulb mr-1.5" aria-hidden="true"></i>Learning #1
 										</p>
 										<p class="text-gray-700 dark:text-gray-300 text-base">
@@ -324,8 +324,8 @@
 									</figcaption>
 								</figure>
 
-									<div class="not-prose my-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 px-5 py-4">
-										<p class="text-sm font-semibold text-blue-700 dark:text-blue-400 mb-1">
+									<div class="not-prose my-6 rounded-lg border-l-4 border-teal-500 bg-teal-50 dark:bg-teal-900/20 px-5 py-4">
+										<p class="text-sm font-semibold text-teal-700 dark:text-teal-400 mb-1">
 											<i class="fas fa-lightbulb mr-1.5" aria-hidden="true"></i>Learning #2
 										</p>
 										<p class="text-gray-700 dark:text-gray-300 text-base">
@@ -411,8 +411,8 @@
 										and just learning about them was already a great experience.
 									</p>
 
-									<div class="not-prose my-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 px-5 py-4">
-										<p class="text-sm font-semibold text-blue-700 dark:text-blue-400 mb-1">
+									<div class="not-prose my-6 rounded-lg border-l-4 border-teal-500 bg-teal-50 dark:bg-teal-900/20 px-5 py-4">
+										<p class="text-sm font-semibold text-teal-700 dark:text-teal-400 mb-1">
 											<i class="fas fa-lightbulb mr-1.5" aria-hidden="true"></i>Learning #3
 										</p>
 										<p class="text-gray-700 dark:text-gray-300 text-base">
@@ -467,8 +467,8 @@
 										on the next submission.
 									</p>
 
-									<div class="not-prose my-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 px-5 py-4">
-										<p class="text-sm font-semibold text-blue-700 dark:text-blue-400 mb-1">
+									<div class="not-prose my-6 rounded-lg border-l-4 border-teal-500 bg-teal-50 dark:bg-teal-900/20 px-5 py-4">
+										<p class="text-sm font-semibold text-teal-700 dark:text-teal-400 mb-1">
 											<i class="fas fa-lightbulb mr-1.5" aria-hidden="true"></i>Learning #4
 										</p>
 										<p class="text-gray-700 dark:text-gray-300 text-base">
@@ -510,7 +510,7 @@
 											href="https://nearbygame.com"
 											target="_blank"
 											rel="noopener noreferrer"
-											class="text-blue-600 dark:text-blue-400 font-medium hover:underline"
+											class="text-teal-600 dark:text-teal-400 font-medium hover:underline"
 										>
 											nearbygame.com
 										</a>
@@ -539,7 +539,7 @@
 									{#each tableOfContents as item (item.id)}
 										<a
 											href="#{item.id}"
-											class="block rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+											class="block rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-teal-50 dark:hover:bg-teal-900/20 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
 										>
 											{item.title}
 										</a>
@@ -561,7 +561,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on Twitter"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-twitter text-xs"></i>
 									</a>
@@ -570,7 +570,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on LinkedIn"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-linkedin-in text-xs"></i>
 									</a>

--- a/src/routes/blog/why-i-build-nocloud-chat/+page.svelte
+++ b/src/routes/blog/why-i-build-nocloud-chat/+page.svelte
@@ -84,7 +84,7 @@
 					onclick={() => (showTOC = !showTOC)}
 					class="flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
 				>
-					<i class="fas fa-list text-blue-500 text-xs" aria-hidden="true"></i>
+					<i class="fas fa-list text-teal-500 text-xs" aria-hidden="true"></i>
 					<span class="hidden sm:inline">{showTOC ? 'Hide' : 'Show'} Contents</span>
 					<i class="fas fa-chevron-{showTOC ? 'up' : 'down'} text-gray-400 text-xs" aria-hidden="true"></i>
 				</button>
@@ -116,7 +116,7 @@
 				<span class="text-gray-600 dark:text-gray-300">Why Do I Build NoCloud Chat</span>
 			</nav>
 			<div class="mb-4 flex items-center gap-3">
-				<span class="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-500 dark:text-blue-400">
+				<span class="rounded-full bg-teal-500/10 px-3 py-1 text-xs font-medium text-teal-500 dark:text-teal-400">
 					<i class="fas fa-wifi mr-1.5" aria-hidden="true"></i>NoCloud Chat
 				</span>
 				<span class="rounded-full bg-gray-100 dark:bg-gray-800 px-3 py-1 text-xs font-medium text-gray-500 dark:text-gray-400">
@@ -149,7 +149,7 @@
 								prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-p:leading-relaxed
 								prose-li:text-gray-700 dark:prose-li:text-gray-300 prose-li:mb-2
 								prose-strong:text-gray-900 dark:prose-strong:text-white
-								prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:underline-offset-2
+								prose-a:text-teal-600 dark:prose-a:text-teal-400 prose-a:underline-offset-2
 								[&_section]:scroll-mt-24 [&_h2]:scroll-mt-24">
 
 								<!-- Section 1: Motivation -->
@@ -213,7 +213,7 @@
 										I created six teams: <strong>PM, Tech Lead, Design, Dev, SRM, and Network Security Expert</strong>. Each had its own system prompt and set of responsibilities. Then I handed the entire project over with one instruction: notify me when it is ready to demo.
 									</p>
 
-									<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20 rounded-r-xl">
+									<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20 rounded-r-xl">
 										<p class="mb-0 text-gray-700 dark:text-gray-300 leading-relaxed">
 											<strong>Honest take:</strong> The first demo was genuinely impressive. But there were a lot of bugs. We went through multiple demo-and-fix cycles. YOLO mode does not handle UX polish on its own, especially responsiveness and interaction design. Once I gave clear and specific feedback though, the agents understood exactly what to address.
 										</p>
@@ -314,7 +314,7 @@
 									{#each tableOfContents as item (item.id)}
 										<a
 											href="#{item.id}"
-											class="block rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+											class="block rounded-lg px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-teal-50 dark:hover:bg-teal-900/20 hover:text-teal-600 dark:hover:text-teal-400 transition-colors"
 										>
 											{item.title}
 										</a>
@@ -330,7 +330,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on Twitter"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-twitter text-xs"></i>
 									</a>
@@ -339,7 +339,7 @@
 										target="_blank"
 										rel="noopener noreferrer"
 										aria-label="Share on LinkedIn"
-										class="flex-1 rounded-lg bg-blue-50 dark:bg-blue-900/30 p-2 text-center text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+										class="flex-1 rounded-lg bg-teal-50 dark:bg-teal-900/30 p-2 text-center text-sm font-medium text-teal-600 dark:text-teal-400 hover:bg-teal-100 dark:hover:bg-teal-900/50 transition-colors"
 									>
 										<i class="fab fa-linkedin-in text-xs"></i>
 									</a>

--- a/src/routes/mosaic/+page.svelte
+++ b/src/routes/mosaic/+page.svelte
@@ -52,16 +52,16 @@
 
 <!-- Hero Section -->
 <section class="relative py-20 md:py-22 overflow-hidden">
-    <div class="absolute inset-0 bg-gradient-to-br from-blue-900/20 via-transparent to-blue-900/20 pointer-events-none"></div>
+    <div class="absolute inset-0 bg-gradient-to-br from-teal-900/20 via-transparent to-teal-900/20 pointer-events-none"></div>
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 relative">
         <div class="text-center">
             <div class="mb-6">
-                <span class="bg-blue-500/10 text-blue-400 border border-blue-500/20 px-4 py-2 rounded-full text-sm font-medium">
+                <span class="bg-teal-500/10 text-teal-400 border border-teal-500/20 px-4 py-2 rounded-full text-sm font-medium">
                     <i class="fas fa-th mr-2" aria-hidden="true"></i>4-Part Article
                 </span>
             </div>
             <h1 class="font-serif text-4xl md:text-5xl lg:text-6xl font-semibold mb-6 text-gray-900 dark:text-white">
-                From App Stores to <span class="text-blue-600 dark:text-blue-400">App Flows</span>
+                From App Stores to <span class="text-teal-600 dark:text-teal-400">App Flows</span>
             </h1>
             <h2 class="text-2xl md:text-3xl text-gray-600 dark:text-gray-300 mb-8 font-light">
                 Why Mosaic Matters
@@ -71,11 +71,11 @@
             </p>
             <div class="flex flex-wrap gap-4 justify-center">
                 <a href="/mosaic/full-series"
-                   class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-full transition shadow-lg shadow-blue-600/25 font-medium">
+                   class="bg-teal-600 hover:bg-teal-700 text-white px-6 py-3 rounded-full transition shadow-lg shadow-teal-600/25 font-medium">
                     <i class="fas fa-book-open mr-2" aria-hidden="true"></i>Read Full Series
                 </a>
                 <a href="/"
-                   class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 px-6 py-3 rounded-full transition font-medium">
+                   class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-teal-500 hover:text-teal-600 dark:hover:text-teal-400 px-6 py-3 rounded-full transition font-medium">
                     ← Back to Home
                 </a>
             </div>
@@ -93,9 +93,9 @@
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             {#each mosaicSeriesParts as part, index}
-                <article class="group rounded-xl border border-gray-200 dark:border-gray-700/50 bg-white dark:bg-gray-800/50 hover:border-blue-500/50 hover:shadow-lg hover:shadow-blue-500/5 transition-all duration-200 p-6">
+                <article class="group rounded-xl border border-gray-200 dark:border-gray-700/50 bg-white dark:bg-gray-800/50 hover:border-teal-500/50 hover:shadow-lg hover:shadow-teal-500/5 transition-all duration-200 p-6">
                     <div class="flex items-center mb-4">
-                        <div class="w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold mr-4 flex-shrink-0">
+                        <div class="w-10 h-10 bg-teal-600 text-white rounded-full flex items-center justify-center font-bold mr-4 flex-shrink-0">
                             {part.part}
                         </div>
                         <div>
@@ -106,7 +106,7 @@
                     <p class="text-gray-600 dark:text-gray-400 mb-4">
                         {part.description}
                     </p>
-                    <a href="/mosaic/{part.slug}" class="inline-flex min-h-[44px] items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium text-sm transition-colors">
+                    <a href="/mosaic/{part.slug}" class="inline-flex min-h-[44px] items-center text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300 font-medium text-sm transition-colors">
                         Read Part {part.part}
                         <i class="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform" aria-hidden="true"></i>
                     </a>
@@ -119,8 +119,8 @@
 <!-- Read All Parts Option -->
 <section class="py-12">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="rounded-xl bg-gradient-to-r from-blue-500/10 to-blue-500/10 border border-blue-500/20 p-8 text-center">
-            <div class="w-14 h-14 bg-gradient-to-br from-blue-500 to-blue-500 rounded-full flex items-center justify-center mx-auto mb-4">
+        <div class="rounded-xl bg-gradient-to-r from-teal-500/10 to-teal-500/10 border border-teal-500/20 p-8 text-center">
+            <div class="w-14 h-14 bg-gradient-to-br from-teal-500 to-teal-500 rounded-full flex items-center justify-center mx-auto mb-4">
                 <i class="fas fa-book-open text-white text-xl" aria-hidden="true"></i>
             </div>
             <h3 class="text-xl font-bold mb-2 text-gray-900 dark:text-white">Prefer to Read Everything at Once?</h3>
@@ -133,11 +133,11 @@
             </div>
             <div class="flex flex-wrap gap-4 justify-center">
                 <a href="/mosaic/full-series"
-                   class="inline-flex items-center bg-gradient-to-r from-blue-600 to-blue-600 hover:from-blue-700 hover:to-blue-700 text-white px-8 py-3 rounded-full transition font-medium shadow-lg">
+                   class="inline-flex items-center bg-gradient-to-r from-teal-600 to-teal-600 hover:from-teal-700 hover:to-teal-700 text-white px-8 py-3 rounded-full transition font-medium shadow-lg">
                     <i class="fas fa-book-open mr-2" aria-hidden="true"></i>Read Full Series
                 </a>
                 <a href="/mosaic/the-problem-with-apps-today"
-                   class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 px-8 py-3 rounded-full transition font-medium">
+                   class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-teal-500 hover:text-teal-600 dark:hover:text-teal-400 px-8 py-3 rounded-full transition font-medium">
                     <i class="fas fa-play mr-2" aria-hidden="true"></i>Start with Part 1
                 </a>
             </div>

--- a/src/routes/mosaic/adaptive-journeys/+page.svelte
+++ b/src/routes/mosaic/adaptive-journeys/+page.svelte
@@ -38,7 +38,7 @@
 
         <p>Every time you need something new, you're pushed into the same cycle:</p>
 
-        <div class="bg-gradient-to-r from-red-50 to-blue-50 dark:from-red-900/20 dark:to-blue-900/20 rounded-xl p-6 my-6 border border-red-100 dark:border-red-800">
+        <div class="bg-gradient-to-r from-red-50 to-teal-50 dark:from-red-900/20 dark:to-teal-900/20 rounded-xl p-6 my-6 border border-red-100 dark:border-red-800">
             <ol class="space-y-2 text-lg">
                 <li>🔍 Search the app store.</li>
                 <li>📊 Compare dozens of options with nearly identical features.</li>
@@ -66,9 +66,9 @@
                 <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">📱 Traditional Apps</h3>
                 <p class="text-gray-600 dark:text-gray-400">Static: once you install them, they look and behave the same, regardless of your stage in a journey.</p>
             </div>
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 border border-blue-200 dark:border-blue-700">
-                <h3 class="text-xl font-bold text-blue-900 dark:text-blue-100 mb-4">🌊 App Flows</h3>
-                <p class="text-blue-700 dark:text-blue-300">Dynamic and adaptive — living experiences that grow and shrink with your journey.</p>
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 border border-teal-200 dark:border-teal-700">
+                <h3 class="text-xl font-bold text-teal-900 dark:text-teal-100 mb-4">🌊 App Flows</h3>
+                <p class="text-teal-700 dark:text-teal-300">Dynamic and adaptive — living experiences that grow and shrink with your journey.</p>
             </div>
         </div>
 
@@ -80,8 +80,8 @@
             <li><strong>Rearrange themselves automatically as your context shifts.</strong></li>
         </ul>
 
-        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6 my-8">
-            <p class="text-xl font-semibold text-blue-700 dark:text-blue-300 text-center">
+        <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6 my-8">
+            <p class="text-xl font-semibold text-teal-700 dark:text-teal-300 text-center">
                 They are not "one app per problem" — they are <em>living experiences</em> that grow and shrink with your journey.
             </p>
         </div>
@@ -103,8 +103,8 @@
         <p class="mb-6">Let's imagine you're planning a trip to Tokyo.</p>
 
         <div class="clear-left md:clear-none">
-            <h3 class="text-2xl font-bold mt-8 mb-4 text-blue-600 dark:text-blue-400">🛫 Before the trip</h3>
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 mb-6 border border-blue-200 dark:border-blue-700 md:mr-8">
+            <h3 class="text-2xl font-bold mt-8 mb-4 text-teal-600 dark:text-teal-400">🛫 Before the trip</h3>
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 mb-6 border border-teal-200 dark:border-teal-700 md:mr-8">
                 <ul>
                     <li>The App Flow emphasizes your <strong>flight tracker</strong> and <strong>hotel reservation</strong> details.</li>
                     <li>Maps, translation, and restaurant suggestions exist but stay in the background.</li>
@@ -120,8 +120,8 @@
                 </ul>
             </div>
 
-            <h3 class="text-2xl font-bold mt-8 mb-4 text-blue-600 dark:text-blue-400">📸 After the trip</h3>
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 mb-6 border border-blue-200 dark:border-blue-700 md:mr-8">
+            <h3 class="text-2xl font-bold mt-8 mb-4 text-teal-600 dark:text-teal-400">📸 After the trip</h3>
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 mb-6 border border-teal-200 dark:border-teal-700 md:mr-8">
                 <ul>
                     <li>Your <strong>photo gallery</strong> and <strong>spending tracker</strong> take the spotlight.</li>
                     <li>The flight tracker <strong>disappears completely</strong>.</li>
@@ -130,53 +130,53 @@
             </div>
         </div>
 
-        <h3 class="text-2xl font-bold mt-8 mb-4 text-blue-600 dark:text-blue-400">🗂️ Beyond the trip: Disposable & Archivable Flows</h3>
-        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 mb-6 border border-blue-200 dark:border-blue-700">
-            <p class="text-blue-700 dark:text-blue-300 mb-4">Here's where App Flows truly differ from traditional apps:</p>
+        <h3 class="text-2xl font-bold mt-8 mb-4 text-teal-600 dark:text-teal-400">🗂️ Beyond the trip: Disposable & Archivable Flows</h3>
+        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 mb-6 border border-teal-200 dark:border-teal-700">
+            <p class="text-teal-700 dark:text-teal-300 mb-4">Here's where App Flows truly differ from traditional apps:</p>
             <ul class="space-y-3">
                 <li class="flex items-start">
                     <span class="text-2xl mr-3">🗑️</span>
                     <div>
-                        <strong class="text-blue-800 dark:text-blue-200">Disposable by default:</strong>
-                        <span class="text-blue-700 dark:text-blue-300">Once your Tokyo trip is complete, the entire App Flow can gracefully disappear. No cluttered home screen, no forgotten apps taking up storage.</span>
+                        <strong class="text-teal-800 dark:text-teal-200">Disposable by default:</strong>
+                        <span class="text-teal-700 dark:text-teal-300">Once your Tokyo trip is complete, the entire App Flow can gracefully disappear. No cluttered home screen, no forgotten apps taking up storage.</span>
                     </div>
                 </li>
                 <li class="flex items-start">
                     <span class="text-2xl mr-3">📦</span>
                     <div>
-                        <strong class="text-blue-800 dark:text-blue-200">Archivable when needed:</strong>
-                        <span class="text-blue-700 dark:text-blue-300">If you want to keep the flow for reference or reuse, it gets archived with all your preferences, favorite restaurants, and learned patterns intact.</span>
+                        <strong class="text-teal-800 dark:text-teal-200">Archivable when needed:</strong>
+                        <span class="text-teal-700 dark:text-teal-300">If you want to keep the flow for reference or reuse, it gets archived with all your preferences, favorite restaurants, and learned patterns intact.</span>
                     </div>
                 </li>
                 <li class="flex items-start">
                     <span class="text-2xl mr-3">🔄</span>
                     <div>
-                        <strong class="text-blue-800 dark:text-blue-200">Instantly retrievable:</strong>
-                        <span class="text-blue-700 dark:text-blue-300">Planning another trip to Japan two years later? Your archived "Tokyo Trip" flow can be restored instantly, with all your previous preferences and learnings ready to go.</span>
+                        <strong class="text-teal-800 dark:text-teal-200">Instantly retrievable:</strong>
+                        <span class="text-teal-700 dark:text-teal-300">Planning another trip to Japan two years later? Your archived "Tokyo Trip" flow can be restored instantly, with all your previous preferences and learnings ready to go.</span>
                     </div>
                 </li>
             </ul>
         </div>
 
-        <div class="bg-gradient-to-r from-blue-100 to-red-100 dark:from-blue-900/30 dark:to-red-900/30 rounded-xl p-6 my-6 border border-blue-200 dark:border-blue-700">
+        <div class="bg-gradient-to-r from-teal-100 to-red-100 dark:from-teal-900/30 dark:to-red-900/30 rounded-xl p-6 my-6 border border-teal-200 dark:border-teal-700">
             <div class="flex items-center justify-center mb-4">
                 <span class="text-3xl mr-4">💡</span>
-                <h4 class="text-xl font-bold text-blue-800 dark:text-blue-200">The Revolutionary Difference</h4>
+                <h4 class="text-xl font-bold text-teal-800 dark:text-teal-200">The Revolutionary Difference</h4>
             </div>
-            <p class="text-center text-blue-700 dark:text-blue-300 text-lg">
+            <p class="text-center text-teal-700 dark:text-teal-300 text-lg">
                 Instead of <strong>permanent apps</strong> that accumulate on your device forever, you get <strong>temporary experiences</strong>
                 that exist only as long as you need them — and can be recalled when relevant again.
             </p>
         </div>
 
-        <div class="bg-gradient-to-r from-blue-100 to-blue-100 dark:from-blue-900/30 dark:to-blue-900/30 rounded-xl p-8 my-8 border border-blue-200 dark:border-blue-700">
+        <div class="bg-gradient-to-r from-teal-100 to-teal-100 dark:from-teal-900/30 dark:to-teal-900/30 rounded-xl p-8 my-8 border border-teal-200 dark:border-teal-700">
             <div class="flex items-center justify-center mb-4">
                 <span class="text-3xl mr-4">🤝</span>
-                <p class="text-xl font-bold text-center text-blue-700 dark:text-blue-300">
+                <p class="text-xl font-bold text-center text-teal-700 dark:text-teal-300">
                     This isn't just a self-updating app.
                 </p>
             </div>
-            <p class="text-lg text-center text-blue-600 dark:text-blue-400">
+            <p class="text-lg text-center text-teal-600 dark:text-teal-400">
                 It's a <strong>Living Companion</strong> — an app that evolves as your context (location, time, role, and goals).
             </p>
         </div>
@@ -188,14 +188,14 @@
         <p>To be precise:</p>
 
         <div class="grid md:grid-cols-1 gap-6 my-8">
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 border border-blue-200 dark:border-blue-700">
-                <h3 class="text-xl font-bold text-blue-900 dark:text-blue-100 mb-3">🌊 App Flows</h3>
-                <p class="text-blue-700 dark:text-blue-300">The representation of the user's goal or journey. They describe what you want to achieve (plan a trip, complete a course, manage a health check-up) and evolve as your context changes.</p>
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 border border-teal-200 dark:border-teal-700">
+                <h3 class="text-xl font-bold text-teal-900 dark:text-teal-100 mb-3">🌊 App Flows</h3>
+                <p class="text-teal-700 dark:text-teal-300">The representation of the user's goal or journey. They describe what you want to achieve (plan a trip, complete a course, manage a health check-up) and evolve as your context changes.</p>
             </div>
 
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 border border-blue-200 dark:border-blue-700">
-                <h3 class="text-xl font-bold text-blue-900 dark:text-blue-100 mb-3">🎯 Mosaic</h3>
-                <p class="text-blue-700 dark:text-blue-300">The composition engine that interprets App Flows. It brings together the right "tiles" — small modular capabilities like translation, maps, reminders, or payments — and assembles them into a single adaptive experience.</p>
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 border border-teal-200 dark:border-teal-700">
+                <h3 class="text-xl font-bold text-teal-900 dark:text-teal-100 mb-3">🎯 Mosaic</h3>
+                <p class="text-teal-700 dark:text-teal-300">The composition engine that interprets App Flows. It brings together the right "tiles" — small modular capabilities like translation, maps, reminders, or payments — and assembles them into a single adaptive experience.</p>
             </div>
         </div>
 
@@ -203,12 +203,12 @@
             <h3 class="text-2xl font-bold text-center mb-6 text-gray-900 dark:text-white">In short:</h3>
             <div class="grid md:grid-cols-2 gap-6">
                 <div class="text-center">
-                    <div class="bg-blue-500 text-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">🌊</div>
-                    <p class="text-xl font-semibold text-blue-600 dark:text-blue-400">App Flows capture your intent.</p>
+                    <div class="bg-teal-500 text-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">🌊</div>
+                    <p class="text-xl font-semibold text-teal-600 dark:text-teal-400">App Flows capture your intent.</p>
                 </div>
                 <div class="text-center">
-                    <div class="bg-blue-500 text-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">🎯</div>
-                    <p class="text-xl font-semibold text-blue-600 dark:text-blue-400">Mosaic builds the experience around it.</p>
+                    <div class="bg-teal-500 text-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">🎯</div>
+                    <p class="text-xl font-semibold text-teal-600 dark:text-teal-400">Mosaic builds the experience around it.</p>
                 </div>
             </div>
         </div>
@@ -228,28 +228,28 @@
                 <p class="text-green-700 dark:text-green-300">Only what matters now is visible.</p>
             </div>
 
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 border border-blue-200 dark:border-blue-700">
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-4 border border-teal-200 dark:border-teal-700">
                 <div class="flex items-center mb-2">
                     <span class="text-2xl mr-3">⚡</span>
-                    <h3 class="text-lg font-bold text-blue-900 dark:text-blue-100">Less friction</h3>
+                    <h3 class="text-lg font-bold text-teal-900 dark:text-teal-100">Less friction</h3>
                 </div>
-                <p class="text-blue-700 dark:text-blue-300">No more searching, installing, or relearning interfaces.</p>
+                <p class="text-teal-700 dark:text-teal-300">No more searching, installing, or relearning interfaces.</p>
             </div>
 
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 border border-blue-200 dark:border-blue-700">
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-4 border border-teal-200 dark:border-teal-700">
                 <div class="flex items-center mb-2">
                     <span class="text-2xl mr-3">🔍</span>
-                    <h3 class="text-lg font-bold text-blue-900 dark:text-blue-100">More focus</h3>
+                    <h3 class="text-lg font-bold text-teal-900 dark:text-teal-100">More focus</h3>
                 </div>
-                <p class="text-blue-700 dark:text-blue-300">Your app evolves with you, stage by stage.</p>
+                <p class="text-teal-700 dark:text-teal-300">Your app evolves with you, stage by stage.</p>
             </div>
 
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 border border-blue-200 dark:border-blue-700">
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-4 border border-teal-200 dark:border-teal-700">
                 <div class="flex items-center mb-2">
                     <span class="text-2xl mr-3">🤝</span>
-                    <h3 class="text-lg font-bold text-blue-900 dark:text-blue-100">More trust</h3>
+                    <h3 class="text-lg font-bold text-teal-900 dark:text-teal-100">More trust</h3>
                 </div>
-                <p class="text-blue-700 dark:text-blue-300">You know the right tool will surface when you need it.</p>
+                <p class="text-teal-700 dark:text-teal-300">You know the right tool will surface when you need it.</p>
             </div>
 
             <div class="md:col-span-2 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-4 border border-yellow-200 dark:border-yellow-700">
@@ -266,29 +266,29 @@
         <h2>Homework for You</h2>
 
         <div class="space-y-6 my-8">
-            <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6">
+            <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6">
                 <div class="flex items-center space-x-4 mb-3">
-                    <div class="bg-blue-500 text-white w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 font-bold">1</div>
-                    <h3 class="text-lg font-bold text-blue-900 dark:text-blue-100">👉 Homework 1:</h3>
+                    <div class="bg-teal-500 text-white w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 font-bold">1</div>
+                    <h3 class="text-lg font-bold text-teal-900 dark:text-teal-100">👉 Homework 1:</h3>
                 </div>
                 <div class="ml-12">
-                    <p class="text-blue-700 dark:text-blue-300">Think of one journey in your life (a trip, a health check-up, a project, or a course). Write down the stages of that journey. What apps did you use at each stage?</p>
+                    <p class="text-teal-700 dark:text-teal-300">Think of one journey in your life (a trip, a health check-up, a project, or a course). Write down the stages of that journey. What apps did you use at each stage?</p>
                 </div>
             </div>
 
-            <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6">
+            <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6">
                 <div class="flex items-center space-x-4 mb-3">
-                    <div class="bg-blue-500 text-white w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 font-bold">2</div>
-                    <h3 class="text-lg font-bold text-blue-900 dark:text-blue-100">👉 Homework 2:</h3>
+                    <div class="bg-teal-500 text-white w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 font-bold">2</div>
+                    <h3 class="text-lg font-bold text-teal-900 dark:text-teal-100">👉 Homework 2:</h3>
                 </div>
                 <div class="ml-12">
-                    <p class="text-blue-700 dark:text-blue-300">On your phone, scroll through your installed apps. Which ones did you download for a single purpose — and never use again?</p>
+                    <p class="text-teal-700 dark:text-teal-300">On your phone, scroll through your installed apps. Which ones did you download for a single purpose — and never use again?</p>
                 </div>
             </div>
         </div>
 
-        <div class="bg-gradient-to-r from-blue-100 to-blue-100 dark:from-blue-900/30 dark:to-blue-900/30 rounded-xl p-8 my-8 border border-blue-200 dark:border-blue-700">
-            <p class="text-lg text-center text-blue-700 dark:text-blue-300 italic">
+        <div class="bg-gradient-to-r from-teal-100 to-teal-100 dark:from-teal-900/30 dark:to-teal-900/30 rounded-xl p-8 my-8 border border-teal-200 dark:border-teal-700">
+            <p class="text-lg text-center text-teal-700 dark:text-teal-300 italic">
                 Imagine if those weren't permanent apps on your phone, but temporary tiles that appeared in your App Flow when needed, and gracefully disappeared afterward.
             </p>
         </div>
@@ -296,11 +296,11 @@
 
     <!-- Next Up Section -->
     <section class="mt-16">
-        <div class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 rounded-xl p-8 border border-blue-200 dark:border-blue-700">
-            <h3 class="text-2xl font-bold text-center mb-4 text-blue-900 dark:text-blue-100">
+        <div class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 rounded-xl p-8 border border-teal-200 dark:border-teal-700">
+            <h3 class="text-2xl font-bold text-center mb-4 text-teal-900 dark:text-teal-100">
                 Next Up: Part 3 — Under the Hood
             </h3>
-            <p class="text-center text-blue-700 dark:text-blue-300 text-lg">
+            <p class="text-center text-teal-700 dark:text-teal-300 text-lg">
                 We'll look behind the scenes at how App Flows are built: the Context Engine, the Registry of Tiles, the Composer, and how Mosaic keeps them secure and trustworthy.
             </p>
         </div>

--- a/src/routes/mosaic/app-flow-under-the-hood/+page.svelte
+++ b/src/routes/mosaic/app-flow-under-the-hood/+page.svelte
@@ -71,8 +71,8 @@
             <p class="text-lg mb-6">In Mosaic, registries expose <strong>tiles</strong>: modular units made of three layers:</p>
 
             <div class="space-y-8">
-                <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                    <h4 class="text-xl font-semibold mb-3 text-blue-800 dark:text-blue-200">Logic Layer</h4>
+                <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                    <h4 class="text-xl font-semibold mb-3 text-teal-800 dark:text-teal-200">Logic Layer</h4>
                     <p class="text-lg mb-4">Defines what the tile does.</p>
                     <p class="text-lg mb-4">Exposed as functions or API wrappers.</p>
                     <p class="text-lg mb-4 font-medium">Example (TypeScript):</p>
@@ -102,8 +102,8 @@ export async function getWeather(location: string) &#123;
 &lt;/div&gt;</code></pre>
                 </div>
 
-                <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                    <h4 class="text-xl font-semibold mb-3 text-blue-800 dark:text-blue-200">Metadata Layer</h4>
+                <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                    <h4 class="text-xl font-semibold mb-3 text-teal-800 dark:text-teal-200">Metadata Layer</h4>
                     <p class="text-lg mb-4">Tells the Composer when and how to use the tile.</p>
                     <p class="text-lg mb-4 font-medium">Example manifest (JSON):</p>
 
@@ -264,7 +264,7 @@ export async function getWeather(location: string) &#123;
     <section id="homework-for-you">
         <h2 class="text-3xl font-bold mb-6 text-gray-900 dark:text-white">Homework for You</h2>
 
-        <div class="bg-gradient-to-r from-blue-50 to-red-50 dark:from-blue-900/20 dark:to-red-900/20 rounded-xl p-8 mb-6 border border-blue-200 dark:border-blue-800">
+        <div class="bg-gradient-to-r from-teal-50 to-red-50 dark:from-teal-900/20 dark:to-red-900/20 rounded-xl p-8 mb-6 border border-teal-200 dark:border-teal-800">
             <p class="text-lg mb-4"><strong>👉 Homework 1:</strong> Pick one task you'd describe in a sentence ("I'm moving to a new house," "I'm training for a marathon"). What tiles would you need if Mosaic built an App Flow for you?</p>
 
             <p class="text-lg"><strong>👉 Homework 2 (for builders):</strong> Take one feature from your app and imagine it as a tile. Write a simple manifest:</p>

--- a/src/routes/mosaic/full-series/+page.svelte
+++ b/src/routes/mosaic/full-series/+page.svelte
@@ -177,7 +177,7 @@
             {#each fullTOC as item}
                 <button
                     on:click={() => scrollToSection(item.id)}
-                    class="block w-full text-left text-xs py-1 px-2 rounded transition-colors hover:bg-gray-100 dark:hover:bg-gray-700 {activeSectionId === item.id ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300' : 'text-gray-600 dark:text-gray-400'}"
+                    class="block w-full text-left text-xs py-1 px-2 rounded transition-colors hover:bg-gray-100 dark:hover:bg-gray-700 {activeSectionId === item.id ? 'bg-teal-100 dark:bg-teal-900 text-teal-700 dark:text-teal-300' : 'text-gray-600 dark:text-gray-400'}"
                     class:pl-2={item.level === 1}
                     class:pl-4={item.level === 2}
                     class:pl-6={item.level === 3}
@@ -191,16 +191,16 @@
 {/if}
 
 <!-- Hero Section -->
-<section class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 py-16">
+<section class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 py-16">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center">
             <div class="mb-6">
-                <a href="/mosaic" class="inline-flex min-h-[44px] items-center text-blue-600 hover:text-blue-700 font-medium">
+                <a href="/mosaic" class="inline-flex min-h-[44px] items-center text-teal-600 hover:text-teal-700 font-medium">
                     ← Back to Series Overview
                 </a>
             </div>
             <div class="mb-4">
-                <span class="bg-blue-100 text-blue-800 px-4 py-2 rounded-full text-sm font-medium">
+                <span class="bg-teal-100 text-teal-800 px-4 py-2 rounded-full text-sm font-medium">
                     <i class="fas fa-book-open mr-2"></i>Complete Series
                 </span>
             </div>
@@ -232,12 +232,12 @@
 <article class="py-16 bg-white dark:bg-gray-900">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <!-- Note about this page -->
-        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 mb-12 border border-blue-200 dark:border-blue-800">
+        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 mb-12 border border-teal-200 dark:border-teal-800">
             <div class="flex items-start">
-                <i class="fas fa-info-circle text-blue-500 mr-3 mt-1"></i>
+                <i class="fas fa-info-circle text-teal-500 mr-3 mt-1"></i>
                 <div>
-                    <h3 class="font-semibold text-blue-800 dark:text-blue-200 mb-2">Reading the Complete Series</h3>
-                    <p class="text-blue-700 dark:text-blue-300 text-sm">
+                    <h3 class="font-semibold text-teal-800 dark:text-teal-200 mb-2">Reading the Complete Series</h3>
+                    <p class="text-teal-700 dark:text-teal-300 text-sm">
                         This page combines all four parts of the Mosaic series for continuous reading. A floating table of contents appears as you scroll to help navigate between sections. You can also read each part individually from the <a href="/mosaic" class="underline hover:no-underline">series overview</a>.
                     </p>
                 </div>
@@ -246,14 +246,14 @@
 
         <!-- Part 1 Content -->
         <section id="part-1" class="mb-16">
-            <div class="border-l-4 border-blue-500 pl-6 mb-8">
+            <div class="border-l-4 border-teal-500 pl-6 mb-8">
                 <h2 class="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Part 1: The Problem with Apps Today</h2>
                 <p class="text-gray-600 dark:text-gray-400">5 min read • September 12, 2025</p>
             </div>
 
             <div class="prose prose-lg dark:prose-invert max-w-none">
                 <section id="intro" class="mb-12">
-                    <div class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 rounded-xl p-8 mb-8 border border-blue-100 dark:border-blue-800">
+                    <div class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 rounded-xl p-8 mb-8 border border-teal-100 dark:border-teal-800">
                         <p class="text-xl leading-relaxed mb-4">Think about the last time you planned a trip.</p>
 
                         <div class="space-y-4 text-lg">
@@ -264,17 +264,17 @@
                             <p>📸 And after the trip? You probably dug through Photos and a budgeting app to figure out what you spent.</p>
                         </div>
 
-                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 mt-6 border-l-4 border-blue-500">
-                            <p class="text-xl font-semibold text-blue-700 dark:text-blue-300 mb-2">That's five or six apps — all for one journey.</p>
+                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 mt-6 border-l-4 border-teal-500">
+                            <p class="text-xl font-semibold text-teal-700 dark:text-teal-300 mb-2">That's five or six apps — all for one journey.</p>
                             <p class="text-gray-600 dark:text-gray-400">This is normal today. But it doesn't feel right, does it?</p>
                         </div>
                     </div>
 
-                    <p class="text-lg leading-relaxed mb-6">We live in a world where apps are still siloed products. App stores want you to search, install, and learn them one by one. But our lives don't fit into silos. We live in <em class="font-semibold text-blue-600 dark:text-blue-400">flows</em> — trips, health check-ups, courses, projects — and those flows cut across dozens of apps.</p>
+                    <p class="text-lg leading-relaxed mb-6">We live in a world where apps are still siloed products. App stores want you to search, install, and learn them one by one. But our lives don't fit into silos. We live in <em class="font-semibold text-teal-600 dark:text-teal-400">flows</em> — trips, health check-ups, courses, projects — and those flows cut across dozens of apps.</p>
 
                     <div class="text-center my-8">
-                        <p class="text-2xl font-bold text-blue-600 dark:text-blue-400 mb-2">This series is about a different way of thinking:</p>
-                        <p class="text-4xl font-bold bg-gradient-to-r from-blue-600 to-blue-600 bg-clip-text text-transparent">Mosaic</p>
+                        <p class="text-2xl font-bold text-teal-600 dark:text-teal-400 mb-2">This series is about a different way of thinking:</p>
+                        <p class="text-4xl font-bold bg-gradient-to-r from-teal-600 to-teal-600 bg-clip-text text-transparent">Mosaic</p>
                     </div>
                 </section>
 
@@ -306,7 +306,7 @@
                 <section id="what-this-series-will-cover" class="mb-12">
                     <h3 class="text-2xl font-bold mb-4 text-gray-900 dark:text-white">What This Series Will Cover</h3>
 
-                    <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6 my-8">
+                    <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6 my-8">
                         <ul class="space-y-3">
                             <li><strong>Part 1 — The Problem with Apps Today</strong><br>
                                 <span class="text-gray-600 dark:text-gray-400">You're reading it! Why app stores and siloed apps don't fit the modern user journey. Introduce the Mosaic concept at a high level.</span></li>
@@ -342,7 +342,7 @@
 
                     <p class="mb-4">Before the next part, here's a simple exercise:</p>
 
-                    <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6 my-8">
+                    <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6 my-8">
                         <p class="text-lg font-medium mb-3">👉 Think of one thing you did this week that required 3 or more apps.</p>
                         <p class="mb-3">Write them down. How did it feel switching back and forth?</p>
                         <p>Hold onto that example — we'll revisit it in Part 2, when we imagine how Mosaic would handle it.</p>
@@ -353,7 +353,7 @@
 
         <!-- Part 2 Content -->
         <section id="part-2" class="mb-16">
-            <div class="border-l-4 border-blue-500 pl-6 mb-8">
+            <div class="border-l-4 border-teal-500 pl-6 mb-8">
                 <h2 class="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Part 2: Adaptive Journeys in App Flows</h2>
                 <p class="text-gray-600 dark:text-gray-400">7 min read • September 13, 2025</p>
             </div>
@@ -374,7 +374,7 @@
 
                     <p class="mb-4">Every time you need something new, you're pushed into the same cycle:</p>
 
-                    <div class="bg-gradient-to-r from-red-50 to-blue-50 dark:from-red-900/20 dark:to-blue-900/20 rounded-xl p-6 my-6 border border-red-100 dark:border-red-800">
+                    <div class="bg-gradient-to-r from-red-50 to-teal-50 dark:from-red-900/20 dark:to-teal-900/20 rounded-xl p-6 my-6 border border-red-100 dark:border-red-800">
                         <ol class="space-y-2 text-lg list-decimal pl-6">
                             <li>🔍 Search the app store.</li>
                             <li>📊 Compare dozens of options with nearly identical features.</li>
@@ -402,9 +402,9 @@
                             <h4 class="text-xl font-bold text-gray-900 dark:text-white mb-4">📱 Traditional Apps</h4>
                             <p class="text-gray-600 dark:text-gray-400">Static: once you install them, they look and behave the same, regardless of your stage in a journey.</p>
                         </div>
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 border border-blue-200 dark:border-blue-700">
-                            <h4 class="text-xl font-bold text-blue-900 dark:text-blue-100 mb-4">🌊 App Flows</h4>
-                            <p class="text-blue-700 dark:text-blue-300">Dynamic and adaptive — living experiences that grow and shrink with your journey.</p>
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 border border-teal-200 dark:border-teal-700">
+                            <h4 class="text-xl font-bold text-teal-900 dark:text-teal-100 mb-4">🌊 App Flows</h4>
+                            <p class="text-teal-700 dark:text-teal-300">Dynamic and adaptive — living experiences that grow and shrink with your journey.</p>
                         </div>
                     </div>
 
@@ -416,8 +416,8 @@
                         <li><strong>Rearrange themselves automatically as your context shifts.</strong></li>
                     </ul>
 
-                    <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6 my-8">
-                        <p class="text-xl font-semibold text-blue-700 dark:text-blue-300 text-center">
+                    <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6 my-8">
+                        <p class="text-xl font-semibold text-teal-700 dark:text-teal-300 text-center">
                             They are not "one app per problem" — they are <em>living experiences</em> that grow and shrink with your journey.
                         </p>
                     </div>
@@ -439,8 +439,8 @@
                     <p class="mb-6">Let's imagine you're planning a trip to Tokyo.</p>
 
                     <div class="clear-left md:clear-none">
-                        <h4 class="text-xl font-bold mt-8 mb-4 text-blue-600 dark:text-blue-400">🛫 Before the trip</h4>
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 mb-6 border border-blue-200 dark:border-blue-700 md:mr-8">
+                        <h4 class="text-xl font-bold mt-8 mb-4 text-teal-600 dark:text-teal-400">🛫 Before the trip</h4>
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 mb-6 border border-teal-200 dark:border-teal-700 md:mr-8">
                             <ul class="list-disc pl-6">
                                 <li>The App Flow emphasizes your <strong>flight tracker</strong> and <strong>hotel reservation</strong> details.</li>
                                 <li>Maps, translation, and restaurant suggestions exist but stay in the background.</li>
@@ -456,8 +456,8 @@
                             </ul>
                         </div>
 
-                        <h4 class="text-xl font-bold mt-8 mb-4 text-blue-600 dark:text-blue-400">📸 After the trip</h4>
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 mb-6 border border-blue-200 dark:border-blue-700 md:mr-8">
+                        <h4 class="text-xl font-bold mt-8 mb-4 text-teal-600 dark:text-teal-400">📸 After the trip</h4>
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 mb-6 border border-teal-200 dark:border-teal-700 md:mr-8">
                             <ul class="list-disc pl-6">
                                 <li>Your <strong>photo gallery</strong> and <strong>spending tracker</strong> take the spotlight.</li>
                                 <li>The flight tracker <strong>disappears completely</strong>.</li>
@@ -466,53 +466,53 @@
                         </div>
                     </div>
 
-                    <h4 class="text-xl font-bold mt-8 mb-4 text-blue-600 dark:text-blue-400">🗂️ Beyond the trip: Disposable & Archivable Flows</h4>
-                    <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 mb-6 border border-blue-200 dark:border-blue-700">
-                        <p class="text-blue-700 dark:text-blue-300 mb-4">Here's where App Flows truly differ from traditional apps:</p>
+                    <h4 class="text-xl font-bold mt-8 mb-4 text-teal-600 dark:text-teal-400">🗂️ Beyond the trip: Disposable & Archivable Flows</h4>
+                    <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 mb-6 border border-teal-200 dark:border-teal-700">
+                        <p class="text-teal-700 dark:text-teal-300 mb-4">Here's where App Flows truly differ from traditional apps:</p>
                         <ul class="space-y-3 list-none">
                             <li class="flex items-start">
                                 <span class="text-2xl mr-3">🗑️</span>
                                 <div>
-                                    <strong class="text-blue-800 dark:text-blue-200">Disposable by default:</strong>
-                                    <span class="text-blue-700 dark:text-blue-300">Once your Tokyo trip is complete, the entire App Flow can gracefully disappear. No cluttered home screen, no forgotten apps taking up storage.</span>
+                                    <strong class="text-teal-800 dark:text-teal-200">Disposable by default:</strong>
+                                    <span class="text-teal-700 dark:text-teal-300">Once your Tokyo trip is complete, the entire App Flow can gracefully disappear. No cluttered home screen, no forgotten apps taking up storage.</span>
                                 </div>
                             </li>
                             <li class="flex items-start">
                                 <span class="text-2xl mr-3">📦</span>
                                 <div>
-                                    <strong class="text-blue-800 dark:text-blue-200">Archivable when needed:</strong>
-                                    <span class="text-blue-700 dark:text-blue-300">If you want to keep the flow for reference or reuse, it gets archived with all your preferences, favorite restaurants, and learned patterns intact.</span>
+                                    <strong class="text-teal-800 dark:text-teal-200">Archivable when needed:</strong>
+                                    <span class="text-teal-700 dark:text-teal-300">If you want to keep the flow for reference or reuse, it gets archived with all your preferences, favorite restaurants, and learned patterns intact.</span>
                                 </div>
                             </li>
                             <li class="flex items-start">
                                 <span class="text-2xl mr-3">🔄</span>
                                 <div>
-                                    <strong class="text-blue-800 dark:text-blue-200">Instantly retrievable:</strong>
-                                    <span class="text-blue-700 dark:text-blue-300">Planning another trip to Japan two years later? Your archived "Tokyo Trip" flow can be restored instantly, with all your previous preferences and learnings ready to go.</span>
+                                    <strong class="text-teal-800 dark:text-teal-200">Instantly retrievable:</strong>
+                                    <span class="text-teal-700 dark:text-teal-300">Planning another trip to Japan two years later? Your archived "Tokyo Trip" flow can be restored instantly, with all your previous preferences and learnings ready to go.</span>
                                 </div>
                             </li>
                         </ul>
                     </div>
 
-                    <div class="bg-gradient-to-r from-blue-100 to-red-100 dark:from-blue-900/30 dark:to-red-900/30 rounded-xl p-6 my-6 border border-blue-200 dark:border-blue-700">
+                    <div class="bg-gradient-to-r from-teal-100 to-red-100 dark:from-teal-900/30 dark:to-red-900/30 rounded-xl p-6 my-6 border border-teal-200 dark:border-teal-700">
                         <div class="flex items-center justify-center mb-4">
                             <span class="text-3xl mr-4">💡</span>
-                            <h5 class="text-xl font-bold text-blue-800 dark:text-blue-200">The Revolutionary Difference</h5>
+                            <h5 class="text-xl font-bold text-teal-800 dark:text-teal-200">The Revolutionary Difference</h5>
                         </div>
-                        <p class="text-center text-blue-700 dark:text-blue-300 text-lg">
+                        <p class="text-center text-teal-700 dark:text-teal-300 text-lg">
                             Instead of <strong>permanent apps</strong> that accumulate on your device forever, you get <strong>temporary experiences</strong>
                             that exist only as long as you need them — and can be recalled when relevant again.
                         </p>
                     </div>
 
-                    <div class="bg-gradient-to-r from-blue-100 to-blue-100 dark:from-blue-900/30 dark:to-blue-900/30 rounded-xl p-8 my-8 border border-blue-200 dark:border-blue-700">
+                    <div class="bg-gradient-to-r from-teal-100 to-teal-100 dark:from-teal-900/30 dark:to-teal-900/30 rounded-xl p-8 my-8 border border-teal-200 dark:border-teal-700">
                         <div class="flex items-center justify-center mb-4">
                             <span class="text-3xl mr-4">🤝</span>
-                            <p class="text-xl font-bold text-center text-blue-700 dark:text-blue-300">
+                            <p class="text-xl font-bold text-center text-teal-700 dark:text-teal-300">
                                 This isn't just a self-updating app.
                             </p>
                         </div>
-                        <p class="text-lg text-center text-blue-600 dark:text-blue-400">
+                        <p class="text-lg text-center text-teal-600 dark:text-teal-400">
                             It's a <strong>Living Companion</strong> — an app that evolves as your context (location, time, role, and goals).
                         </p>
                     </div>
@@ -524,14 +524,14 @@
                     <p class="mb-4">To be precise:</p>
 
                     <div class="grid md:grid-cols-1 gap-6 my-8">
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 border border-blue-200 dark:border-blue-700">
-                            <h4 class="text-xl font-bold text-blue-900 dark:text-blue-100 mb-3">🌊 App Flows</h4>
-                            <p class="text-blue-700 dark:text-blue-300">The representation of the user's goal or journey. They describe what you want to achieve (plan a trip, complete a course, manage a health check-up) and evolve as your context changes.</p>
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 border border-teal-200 dark:border-teal-700">
+                            <h4 class="text-xl font-bold text-teal-900 dark:text-teal-100 mb-3">🌊 App Flows</h4>
+                            <p class="text-teal-700 dark:text-teal-300">The representation of the user's goal or journey. They describe what you want to achieve (plan a trip, complete a course, manage a health check-up) and evolve as your context changes.</p>
                         </div>
 
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-6 border border-blue-200 dark:border-blue-700">
-                            <h4 class="text-xl font-bold text-blue-900 dark:text-blue-100 mb-3">🎯 Mosaic</h4>
-                            <p class="text-blue-700 dark:text-blue-300">The composition engine that interprets App Flows. It brings together the right "tiles" — small modular capabilities like translation, maps, reminders, or payments — and assembles them into a single adaptive experience.</p>
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-xl p-6 border border-teal-200 dark:border-teal-700">
+                            <h4 class="text-xl font-bold text-teal-900 dark:text-teal-100 mb-3">🎯 Mosaic</h4>
+                            <p class="text-teal-700 dark:text-teal-300">The composition engine that interprets App Flows. It brings together the right "tiles" — small modular capabilities like translation, maps, reminders, or payments — and assembles them into a single adaptive experience.</p>
                         </div>
                     </div>
 
@@ -539,12 +539,12 @@
                         <h4 class="text-2xl font-bold text-center mb-6 text-gray-900 dark:text-white">In short:</h4>
                         <div class="grid md:grid-cols-2 gap-6">
                             <div class="text-center">
-                                <div class="bg-blue-500 text-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">🌊</div>
-                                <p class="text-xl font-semibold text-blue-600 dark:text-blue-400">App Flows capture your intent.</p>
+                                <div class="bg-teal-500 text-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">🌊</div>
+                                <p class="text-xl font-semibold text-teal-600 dark:text-teal-400">App Flows capture your intent.</p>
                             </div>
                             <div class="text-center">
-                                <div class="bg-blue-500 text-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">🎯</div>
-                                <p class="text-xl font-semibold text-blue-600 dark:text-blue-400">Mosaic builds the experience around it.</p>
+                                <div class="bg-teal-500 text-white w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4 text-xl font-bold">🎯</div>
+                                <p class="text-xl font-semibold text-teal-600 dark:text-teal-400">Mosaic builds the experience around it.</p>
                             </div>
                         </div>
                     </div>
@@ -564,28 +564,28 @@
                             <p class="text-green-700 dark:text-green-300">Only what matters now is visible.</p>
                         </div>
 
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 border border-blue-200 dark:border-blue-700">
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-4 border border-teal-200 dark:border-teal-700">
                             <div class="flex items-center mb-2">
                                 <span class="text-2xl mr-3">⚡</span>
-                                <h5 class="text-lg font-bold text-blue-900 dark:text-blue-100">Less friction</h5>
+                                <h5 class="text-lg font-bold text-teal-900 dark:text-teal-100">Less friction</h5>
                             </div>
-                            <p class="text-blue-700 dark:text-blue-300">No more searching, installing, or relearning interfaces.</p>
+                            <p class="text-teal-700 dark:text-teal-300">No more searching, installing, or relearning interfaces.</p>
                         </div>
 
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 border border-blue-200 dark:border-blue-700">
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-4 border border-teal-200 dark:border-teal-700">
                             <div class="flex items-center mb-2">
                                 <span class="text-2xl mr-3">🔍</span>
-                                <h5 class="text-lg font-bold text-blue-900 dark:text-blue-100">More focus</h5>
+                                <h5 class="text-lg font-bold text-teal-900 dark:text-teal-100">More focus</h5>
                             </div>
-                            <p class="text-blue-700 dark:text-blue-300">Your app evolves with you, stage by stage.</p>
+                            <p class="text-teal-700 dark:text-teal-300">Your app evolves with you, stage by stage.</p>
                         </div>
 
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 border border-blue-200 dark:border-blue-700">
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-4 border border-teal-200 dark:border-teal-700">
                             <div class="flex items-center mb-2">
                                 <span class="text-2xl mr-3">🤝</span>
-                                <h5 class="text-lg font-bold text-blue-900 dark:text-blue-100">More trust</h5>
+                                <h5 class="text-lg font-bold text-teal-900 dark:text-teal-100">More trust</h5>
                             </div>
-                            <p class="text-blue-700 dark:text-blue-300">You know the right tool will surface when you need it.</p>
+                            <p class="text-teal-700 dark:text-teal-300">You know the right tool will surface when you need it.</p>
                         </div>
 
                         <div class="md:col-span-2 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg p-4 border border-yellow-200 dark:border-yellow-700">
@@ -602,29 +602,29 @@
                     <h3 class="text-2xl font-bold mb-4 text-gray-900 dark:text-white">Homework for You</h3>
 
                     <div class="space-y-6 my-8">
-                        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6">
+                        <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6">
                             <div class="flex items-center space-x-4 mb-3">
-                                <div class="bg-blue-500 text-white w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 font-bold">1</div>
-                                <h4 class="text-lg font-bold text-blue-900 dark:text-blue-100">👉 Homework 1:</h4>
+                                <div class="bg-teal-500 text-white w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 font-bold">1</div>
+                                <h4 class="text-lg font-bold text-teal-900 dark:text-teal-100">👉 Homework 1:</h4>
                             </div>
                             <div class="ml-12">
-                                <p class="text-blue-700 dark:text-blue-300">Think of one journey in your life (a trip, a health check-up, a project, or a course). Write down the stages of that journey. What apps did you use at each stage?</p>
+                                <p class="text-teal-700 dark:text-teal-300">Think of one journey in your life (a trip, a health check-up, a project, or a course). Write down the stages of that journey. What apps did you use at each stage?</p>
                             </div>
                         </div>
 
-                        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6">
+                        <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6">
                             <div class="flex items-center space-x-4 mb-3">
-                                <div class="bg-blue-500 text-white w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 font-bold">2</div>
-                                <h4 class="text-lg font-bold text-blue-900 dark:text-blue-100">👉 Homework 2:</h4>
+                                <div class="bg-teal-500 text-white w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 font-bold">2</div>
+                                <h4 class="text-lg font-bold text-teal-900 dark:text-teal-100">👉 Homework 2:</h4>
                             </div>
                             <div class="ml-12">
-                                <p class="text-blue-700 dark:text-blue-300">On your phone, scroll through your installed apps. Which ones did you download for a single purpose — and never use again?</p>
+                                <p class="text-teal-700 dark:text-teal-300">On your phone, scroll through your installed apps. Which ones did you download for a single purpose — and never use again?</p>
                             </div>
                         </div>
                     </div>
 
-                    <div class="bg-gradient-to-r from-blue-100 to-blue-100 dark:from-blue-900/30 dark:to-blue-900/30 rounded-xl p-8 my-8 border border-blue-200 dark:border-blue-700">
-                        <p class="text-lg text-center text-blue-700 dark:text-blue-300 italic">
+                    <div class="bg-gradient-to-r from-teal-100 to-teal-100 dark:from-teal-900/30 dark:to-teal-900/30 rounded-xl p-8 my-8 border border-teal-200 dark:border-teal-700">
+                        <p class="text-lg text-center text-teal-700 dark:text-teal-300 italic">
                             Imagine if those weren't permanent apps on your phone, but temporary tiles that appeared in your App Flow when needed, and gracefully disappeared afterward.
                         </p>
                     </div>
@@ -634,7 +634,7 @@
 
         <!-- Part 3 Content -->
         <section id="part-3" class="mb-16">
-            <div class="border-l-4 border-blue-500 pl-6 mb-8">
+            <div class="border-l-4 border-teal-500 pl-6 mb-8">
                 <h2 class="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Part 3: Under the Hood of App Flows</h2>
                 <p class="text-gray-600 dark:text-gray-400">15 min read • September 13, 2025</p>
             </div>
@@ -682,8 +682,8 @@
                         <p class="text-lg mb-6">In Mosaic, registries expose <strong>tiles</strong>: modular units made of three layers:</p>
 
                         <div class="space-y-8">
-                            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                                <h5 class="text-lg font-semibold mb-3 text-blue-800 dark:text-blue-200">Logic Layer</h5>
+                            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                                <h5 class="text-lg font-semibold mb-3 text-teal-800 dark:text-teal-200">Logic Layer</h5>
                                 <p class="text-lg mb-4">Defines what the tile does.</p>
                                 <p class="text-lg mb-4">Exposed as functions or API wrappers.</p>
                                 <p class="text-lg mb-4 font-medium">Example (TypeScript):</p>
@@ -713,8 +713,8 @@ export async function getWeather(location: string) &#123;
 &lt;/div&gt;</code></pre>
                             </div>
 
-                            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                                <h5 class="text-lg font-semibold mb-3 text-blue-800 dark:text-blue-200">Metadata Layer</h5>
+                            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                                <h5 class="text-lg font-semibold mb-3 text-teal-800 dark:text-teal-200">Metadata Layer</h5>
                                 <p class="text-lg mb-4">Tells the Composer when and how to use the tile.</p>
                                 <p class="text-lg mb-4 font-medium">Example manifest (JSON):</p>
 
@@ -875,7 +875,7 @@ export async function getWeather(location: string) &#123;
                 <section id="homework-3" class="mb-12">
                     <h3 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">Homework for You</h3>
 
-                    <div class="bg-gradient-to-r from-blue-50 to-red-50 dark:from-blue-900/20 dark:to-red-900/20 rounded-xl p-8 mb-6 border border-blue-200 dark:border-blue-800">
+                    <div class="bg-gradient-to-r from-teal-50 to-red-50 dark:from-teal-900/20 dark:to-red-900/20 rounded-xl p-8 mb-6 border border-teal-200 dark:border-teal-800">
                         <p class="text-lg mb-4"><strong>👉 Homework 1:</strong> Pick one task you'd describe in a sentence ("I'm moving to a new house," "I'm training for a marathon"). What tiles would you need if Mosaic built an App Flow for you?</p>
 
                         <p class="text-lg"><strong>👉 Homework 2 (for builders):</strong> Take one feature from your app and imagine it as a tile. Write a simple manifest:</p>
@@ -891,7 +891,7 @@ export async function getWeather(location: string) &#123;
 
         <!-- Part 4 Content -->
         <section id="part-4" class="mb-16">
-            <div class="border-l-4 border-blue-500 pl-6 mb-8">
+            <div class="border-l-4 border-teal-500 pl-6 mb-8">
                 <h2 class="text-3xl font-bold mb-2 text-gray-900 dark:text-white">Part 4: The Near Future and Beyond</h2>
                 <p class="text-gray-600 dark:text-gray-400">8 min read • September 13, 2025</p>
             </div>
@@ -943,7 +943,7 @@ export async function getWeather(location: string) &#123;
 
                         <p class="text-lg mb-6">This means you install once, and all flows open inside that single container.</p>
 
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 mb-6 border border-blue-200 dark:border-blue-800">
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 mb-6 border border-teal-200 dark:border-teal-800">
                             <ul class="text-lg space-y-2 list-disc pl-6">
                                 <li>To the OS, it's one PWA (one icon, one storage).</li>
                                 <li>To the user, each flow feels like a different app because the Composer dynamically reshapes the UI based on the flow ID.</li>
@@ -971,25 +971,25 @@ export async function getWeather(location: string) &#123;
                                 <p class="text-lg">Flows evolve without reinstallations.</p>
                             </div>
 
-                            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                                <h5 class="text-lg font-semibold mb-3 text-blue-800 dark:text-blue-200">Cross-platform reach</h5>
+                            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                                <h5 class="text-lg font-semibold mb-3 text-teal-800 dark:text-teal-200">Cross-platform reach</h5>
                                 <p class="text-lg mb-2">PWAs run in browsers, mobile, and desktop.</p>
                                 <p class="text-lg">Flows are just links — instantly accessible.</p>
                             </div>
 
-                            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                                <h5 class="text-lg font-semibold mb-3 text-blue-800 dark:text-blue-200">Installability</h5>
+                            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                                <h5 class="text-lg font-semibold mb-3 text-teal-800 dark:text-teal-200">Installability</h5>
                                 <p class="text-lg mb-2">The container can live on your home screen.</p>
                                 <p class="text-lg">Users can "install Mosaic" once, but still open any App Flow link.</p>
                             </div>
 
-                            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                                <h5 class="text-lg font-semibold mb-3 text-blue-800 dark:text-blue-200">Offline capabilities</h5>
+                            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                                <h5 class="text-lg font-semibold mb-3 text-teal-800 dark:text-teal-200">Offline capabilities</h5>
                                 <p class="text-lg">Tiles can cache data or run local logic when offline.</p>
                             </div>
 
-                            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                                <h5 class="text-lg font-semibold mb-3 text-blue-800 dark:text-blue-200">Instant shareability</h5>
+                            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                                <h5 class="text-lg font-semibold mb-3 text-teal-800 dark:text-teal-200">Instant shareability</h5>
                                 <p class="text-lg mb-2">A Tokyo Trip flow is just a URL you can send to a friend.</p>
                                 <p class="text-lg">When they click, it runs inside their Mosaic container (or in the browser if they haven't installed yet).</p>
                             </div>
@@ -1055,11 +1055,11 @@ export async function getWeather(location: string) &#123;
                     <h3 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">The Roadmap</h3>
 
                     <div class="space-y-8">
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                            <h4 class="text-lg font-semibold mb-3 text-blue-800 dark:text-blue-200">Today</h4>
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                            <h4 class="text-lg font-semibold mb-3 text-teal-800 dark:text-teal-200">Today</h4>
                             <ul class="text-lg space-y-2 list-disc pl-6">
-                                <li><code class="bg-blue-100 dark:bg-blue-800 px-2 py-1 rounded">&#123;abc.com&#125;</code> as a container PWA.</li>
-                                <li>App Flows are just routes (<code class="bg-blue-100 dark:bg-blue-800 px-2 py-1 rounded">/appflow/:flowId</code>) inside it.</li>
+                                <li><code class="bg-teal-100 dark:bg-teal-800 px-2 py-1 rounded">&#123;abc.com&#125;</code> as a container PWA.</li>
+                                <li>App Flows are just routes (<code class="bg-teal-100 dark:bg-teal-800 px-2 py-1 rounded">/appflow/:flowId</code>) inside it.</li>
                                 <li>Install once, open any flow by link.</li>
                             </ul>
                         </div>
@@ -1073,8 +1073,8 @@ export async function getWeather(location: string) &#123;
                             </ul>
                         </div>
 
-                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                            <h4 class="text-lg font-semibold mb-3 text-blue-800 dark:text-blue-200">Long Term</h4>
+                        <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                            <h4 class="text-lg font-semibold mb-3 text-teal-800 dark:text-teal-200">Long Term</h4>
                             <ul class="text-lg space-y-2 list-disc pl-6">
                                 <li>Registry management at the OS level.</li>
                                 <li>Adaptive App Flows become first-class citizens of the OS.</li>
@@ -1091,7 +1091,7 @@ export async function getWeather(location: string) &#123;
 
                     <p class="text-lg mb-4">But the long-term vision is bigger: Mosaic as an OS-native orchestrator, with registries managed at the system level. Unlike MCP's chat-first approach, Mosaic enables goal-first disposable apps that adapt and disappear when finished.</p>
 
-                    <div class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 rounded-xl p-8 mb-6 border border-blue-200 dark:border-blue-800">
+                    <div class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 rounded-xl p-8 mb-6 border border-teal-200 dark:border-teal-800">
                         <p class="text-xl font-semibold text-center mb-4">The future isn't about apps you hunt down and install.</p>
                         <p class="text-xl font-semibold text-center">It's about flows that find you, adapt with you, and vanish when the job is done.</p>
                     </div>
@@ -1100,27 +1100,27 @@ export async function getWeather(location: string) &#123;
                 <section id="homework-4" class="mb-12">
                     <h3 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">Homework for You</h3>
 
-                    <div class="bg-gradient-to-r from-blue-50 to-red-50 dark:from-blue-900/20 dark:to-red-900/20 rounded-xl p-8 mb-6 border border-blue-200 dark:border-blue-800">
+                    <div class="bg-gradient-to-r from-teal-50 to-red-50 dark:from-teal-900/20 dark:to-red-900/20 rounded-xl p-8 mb-6 border border-teal-200 dark:border-teal-800">
                         <p class="text-lg mb-4"><strong>👉 Homework 1:</strong> Look at the URLs you used today. How many of them could be App Flows inside one container PWA instead of separate apps?</p>
 
-                        <p class="text-lg"><strong>👉 Homework 2:</strong> If you're technical, read a PWA manifest on one of your installed web apps. Notice the scope field. Can you imagine how <code class="bg-blue-100 dark:bg-blue-800 px-2 py-1 rounded">/appflow/:flowId</code> could all be grouped under one container?</p>
+                        <p class="text-lg"><strong>👉 Homework 2:</strong> If you're technical, read a PWA manifest on one of your installed web apps. Notice the scope field. Can you imagine how <code class="bg-teal-100 dark:bg-teal-800 px-2 py-1 rounded">/appflow/:flowId</code> could all be grouped under one container?</p>
                     </div>
                 </section>
             </div>
         </section>
 
         <!-- Series conclusion -->
-        <section class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 rounded-xl p-8 border border-blue-200 dark:border-blue-800">
+        <section class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 rounded-xl p-8 border border-teal-200 dark:border-teal-800">
             <div class="text-center">
                 <h3 class="text-2xl font-bold mb-4 text-gray-900 dark:text-white">Thank You for Reading!</h3>
                 <p class="text-gray-600 dark:text-gray-300 mb-6">
                     You've completed the entire Mosaic series. Share your thoughts and continue the conversation.
                 </p>
                 <div class="flex flex-wrap gap-4 justify-center">
-                    <a href="/mosaic" class="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded-full transition">
+                    <a href="/mosaic" class="bg-teal-500 hover:bg-teal-600 text-white px-6 py-3 rounded-full transition">
                         ← Back to Series Overview
                     </a>
-                    <a href="/" class="border border-blue-500 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20 px-6 py-3 rounded-full transition">
+                    <a href="/" class="border border-teal-500 text-teal-500 hover:bg-teal-50 dark:hover:bg-teal-900/20 px-6 py-3 rounded-full transition">
                         Explore More Articles
                     </a>
                 </div>

--- a/src/routes/mosaic/near-future-and-beyond/+page.svelte
+++ b/src/routes/mosaic/near-future-and-beyond/+page.svelte
@@ -75,7 +75,7 @@
 
             <p class="text-lg mb-6">This means you install once, and all flows open inside that single container.</p>
 
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 mb-6 border border-blue-200 dark:border-blue-800">
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 mb-6 border border-teal-200 dark:border-teal-800">
                 <ul class="text-lg space-y-2 list-disc pl-6">
                     <li>To the OS, it's one PWA (one icon, one storage).</li>
                     <li>To the user, each flow feels like a different app because the Composer dynamically reshapes the UI based on the flow ID.</li>
@@ -103,25 +103,25 @@
                     <p class="text-lg">Flows evolve without reinstallations.</p>
                 </div>
 
-                <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                    <h4 class="text-xl font-semibold mb-3 text-blue-800 dark:text-blue-200">Cross-platform reach</h4>
+                <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                    <h4 class="text-xl font-semibold mb-3 text-teal-800 dark:text-teal-200">Cross-platform reach</h4>
                     <p class="text-lg mb-2">PWAs run in browsers, mobile, and desktop.</p>
                     <p class="text-lg">Flows are just links — instantly accessible.</p>
                 </div>
 
-                <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                    <h4 class="text-xl font-semibold mb-3 text-blue-800 dark:text-blue-200">Installability</h4>
+                <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                    <h4 class="text-xl font-semibold mb-3 text-teal-800 dark:text-teal-200">Installability</h4>
                     <p class="text-lg mb-2">The container can live on your home screen.</p>
                     <p class="text-lg">Users can "install Mosaic" once, but still open any App Flow link.</p>
                 </div>
 
-                <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                    <h4 class="text-xl font-semibold mb-3 text-blue-800 dark:text-blue-200">Offline capabilities</h4>
+                <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                    <h4 class="text-xl font-semibold mb-3 text-teal-800 dark:text-teal-200">Offline capabilities</h4>
                     <p class="text-lg">Tiles can cache data or run local logic when offline.</p>
                 </div>
 
-                <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                    <h4 class="text-xl font-semibold mb-3 text-blue-800 dark:text-blue-200">Instant shareability</h4>
+                <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                    <h4 class="text-xl font-semibold mb-3 text-teal-800 dark:text-teal-200">Instant shareability</h4>
                     <p class="text-lg mb-2">A Tokyo Trip flow is just a URL you can send to a friend.</p>
                     <p class="text-lg">When they click, it runs inside their Mosaic container (or in the browser if they haven't installed yet).</p>
                 </div>
@@ -187,11 +187,11 @@
         <h2 class="text-3xl font-bold mb-6 text-gray-900 dark:text-white">The Roadmap</h2>
 
         <div class="space-y-8">
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                <h3 class="text-xl font-semibold mb-3 text-blue-800 dark:text-blue-200">Today</h3>
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                <h3 class="text-xl font-semibold mb-3 text-teal-800 dark:text-teal-200">Today</h3>
                 <ul class="text-lg space-y-2 list-disc pl-6">
-                    <li><code class="bg-blue-100 dark:bg-blue-800 px-2 py-1 rounded">&#123;abc.com&#125;</code> as a container PWA.</li>
-                    <li>App Flows are just routes (<code class="bg-blue-100 dark:bg-blue-800 px-2 py-1 rounded">/appflow/:flowId</code>) inside it.</li>
+                    <li><code class="bg-teal-100 dark:bg-teal-800 px-2 py-1 rounded">&#123;abc.com&#125;</code> as a container PWA.</li>
+                    <li>App Flows are just routes (<code class="bg-teal-100 dark:bg-teal-800 px-2 py-1 rounded">/appflow/:flowId</code>) inside it.</li>
                     <li>Install once, open any flow by link.</li>
                 </ul>
             </div>
@@ -205,8 +205,8 @@
                 </ul>
             </div>
 
-            <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-6 border border-blue-200 dark:border-blue-800">
-                <h3 class="text-xl font-semibold mb-3 text-blue-800 dark:text-blue-200">Long Term</h3>
+            <div class="bg-teal-50 dark:bg-teal-900/20 rounded-lg p-6 border border-teal-200 dark:border-teal-800">
+                <h3 class="text-xl font-semibold mb-3 text-teal-800 dark:text-teal-200">Long Term</h3>
                 <ul class="text-lg space-y-2 list-disc pl-6">
                     <li>Registry management at the OS level.</li>
                     <li>Adaptive App Flows become first-class citizens of the OS.</li>
@@ -223,7 +223,7 @@
 
         <p class="text-lg mb-4">But the long-term vision is bigger: Mosaic as an OS-native orchestrator, with registries managed at the system level. Unlike MCP's chat-first approach, Mosaic enables goal-first disposable apps that adapt and disappear when finished.</p>
 
-        <div class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 rounded-xl p-8 mb-6 border border-blue-200 dark:border-blue-800">
+        <div class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 rounded-xl p-8 mb-6 border border-teal-200 dark:border-teal-800">
             <p class="text-xl font-semibold text-center mb-4">The future isn't about apps you hunt down and install.</p>
             <p class="text-xl font-semibold text-center">It's about flows that find you, adapt with you, and vanish when the job is done.</p>
         </div>
@@ -232,10 +232,10 @@
     <section id="homework-for-you">
         <h2 class="text-3xl font-bold mb-6 text-gray-900 dark:text-white">Homework for You</h2>
 
-        <div class="bg-gradient-to-r from-blue-50 to-red-50 dark:from-blue-900/20 dark:to-red-900/20 rounded-xl p-8 mb-6 border border-blue-200 dark:border-blue-800">
+        <div class="bg-gradient-to-r from-teal-50 to-red-50 dark:from-teal-900/20 dark:to-red-900/20 rounded-xl p-8 mb-6 border border-teal-200 dark:border-teal-800">
             <p class="text-lg mb-4"><strong>👉 Homework 1:</strong> Look at the URLs you used today. How many of them could be App Flows inside one container PWA instead of separate apps?</p>
 
-            <p class="text-lg"><strong>👉 Homework 2:</strong> If you're technical, read a PWA manifest on one of your installed web apps. Notice the scope field. Can you imagine how <code class="bg-blue-100 dark:bg-blue-800 px-2 py-1 rounded">/appflow/:flowId</code> could all be grouped under one container?</p>
+            <p class="text-lg"><strong>👉 Homework 2:</strong> If you're technical, read a PWA manifest on one of your installed web apps. Notice the scope field. Can you imagine how <code class="bg-teal-100 dark:bg-teal-800 px-2 py-1 rounded">/appflow/:flowId</code> could all be grouped under one container?</p>
         </div>
     </section>
 </BaseSeriesPage>

--- a/src/routes/mosaic/the-problem-with-apps-today/+page.svelte
+++ b/src/routes/mosaic/the-problem-with-apps-today/+page.svelte
@@ -23,7 +23,7 @@
 <BaseSeriesPage {articleData} {navigation} {tableOfContents}>
     <!-- Article Content -->
     <section id="intro">
-        <div class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 rounded-xl p-8 mb-8 border border-blue-100 dark:border-blue-800">
+        <div class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 rounded-xl p-8 mb-8 border border-teal-100 dark:border-teal-800">
             <p class="text-xl leading-relaxed mb-4">Think about the last time you planned a trip.</p>
 
             <div class="space-y-4 text-lg">
@@ -34,17 +34,17 @@
                 <p>📸 And after the trip? You probably dug through Photos and a budgeting app to figure out what you spent.</p>
             </div>
 
-            <div class="bg-white dark:bg-gray-800 rounded-lg p-6 mt-6 border-l-4 border-blue-500">
-                <p class="text-xl font-semibold text-blue-700 dark:text-blue-300 mb-2">That's five or six apps — all for one journey.</p>
+            <div class="bg-white dark:bg-gray-800 rounded-lg p-6 mt-6 border-l-4 border-teal-500">
+                <p class="text-xl font-semibold text-teal-700 dark:text-teal-300 mb-2">That's five or six apps — all for one journey.</p>
                 <p class="text-gray-600 dark:text-gray-400">This is normal today. But it doesn't feel right, does it?</p>
             </div>
         </div>
 
-        <p class="text-lg leading-relaxed mb-6">We live in a world where apps are still siloed products. App stores want you to search, install, and learn them one by one. But our lives don't fit into silos. We live in <em class="font-semibold text-blue-600 dark:text-blue-400">flows</em> — trips, health check-ups, courses, projects — and those flows cut across dozens of apps.</p>
+        <p class="text-lg leading-relaxed mb-6">We live in a world where apps are still siloed products. App stores want you to search, install, and learn them one by one. But our lives don't fit into silos. We live in <em class="font-semibold text-teal-600 dark:text-teal-400">flows</em> — trips, health check-ups, courses, projects — and those flows cut across dozens of apps.</p>
 
         <div class="text-center my-8">
-            <p class="text-2xl font-bold text-blue-600 dark:text-blue-400 mb-2">This series is about a different way of thinking:</p>
-            <p class="text-4xl font-bold bg-gradient-to-r from-blue-600 to-blue-600 bg-clip-text text-transparent">Mosaic</p>
+            <p class="text-2xl font-bold text-teal-600 dark:text-teal-400 mb-2">This series is about a different way of thinking:</p>
+            <p class="text-4xl font-bold bg-gradient-to-r from-teal-600 to-teal-600 bg-clip-text text-transparent">Mosaic</p>
         </div>
     </section>
 
@@ -76,7 +76,7 @@
     <section id="what-this-series-will-cover">
         <h2>What This Series Will Cover</h2>
 
-        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6 my-8">
+        <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6 my-8">
             <ul class="space-y-3">
                 <li><strong>Part 1 — The Problem with Apps Today</strong><br>
                     <span class="text-gray-600 dark:text-gray-400">You're reading it! Why app stores and siloed apps don't fit the modern user journey. Introduce the Mosaic concept at a high level.</span></li>
@@ -112,7 +112,7 @@
 
         <p>Before the next part, here's a simple exercise:</p>
 
-        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6 my-8">
+        <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-700 rounded-lg p-6 my-8">
             <p class="text-lg font-medium mb-3">👉 Think of one thing you did this week that required 3 or more apps.</p>
             <p class="mb-3">Write them down. How did it feel switching back and forth?</p>
             <p>Hold onto that example — we'll revisit it in Part 2, when we imagine how Mosaic would handle it.</p>

--- a/src/routes/series/+page.svelte
+++ b/src/routes/series/+page.svelte
@@ -53,15 +53,15 @@
 
 <!-- Hero Section -->
 <section class="relative py-20 md:py-24 overflow-hidden">
-    <div class="absolute inset-0 bg-gradient-to-br from-blue-900/20 via-transparent to-blue-900/20 pointer-events-none"></div>
+    <div class="absolute inset-0 bg-gradient-to-br from-teal-900/20 via-transparent to-teal-900/20 pointer-events-none"></div>
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative">
         <div class="mb-6">
-            <span class="bg-blue-500/10 text-blue-400 border border-blue-500/20 px-4 py-2 rounded-full text-sm font-medium">
+            <span class="bg-teal-500/10 text-teal-400 border border-teal-500/20 px-4 py-2 rounded-full text-sm font-medium">
                 <i class="fas fa-robot mr-2" aria-hidden="true"></i>AI Development Series — {seriesParts.length} Parts
             </span>
         </div>
         <h1 class="font-serif text-4xl md:text-5xl lg:text-6xl font-semibold mb-6 text-gray-900 dark:text-white">
-            How I Built <span class="text-blue-600 dark:text-blue-400">MiniBreaks.io</span>
+            How I Built <span class="text-teal-600 dark:text-teal-400">MiniBreaks.io</span>
             <span class="block mt-2">With AI</span>
         </h1>
         <p class="text-xl text-gray-600 dark:text-gray-300 mb-8 max-w-3xl mx-auto">
@@ -70,11 +70,11 @@
         </p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
             <a href="/series/full-series"
-               class="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 rounded-full transition font-medium shadow-lg shadow-blue-600/25">
+               class="bg-teal-600 hover:bg-teal-700 text-white px-8 py-3 rounded-full transition font-medium shadow-lg shadow-teal-600/25">
                 <i class="fas fa-book-open mr-2" aria-hidden="true"></i>Read Full Series
             </a>
             <a href="https://minibreaks.io" target="_blank" rel="noopener"
-               class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 px-8 py-3 rounded-full transition font-medium">
+               class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-teal-500 hover:text-teal-600 dark:hover:text-teal-400 px-8 py-3 rounded-full transition font-medium">
                 View MiniBreaks.io <i class="fas fa-external-link-alt ml-2" aria-hidden="true"></i>
             </a>
         </div>
@@ -84,8 +84,8 @@
 <!-- Read All at Once -->
 <section class="py-12">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="rounded-xl bg-gradient-to-r from-blue-500/10 to-blue-500/10 border border-blue-500/20 p-8 text-center">
-            <div class="w-14 h-14 bg-gradient-to-br from-blue-500 to-blue-500 rounded-full flex items-center justify-center mx-auto mb-4">
+        <div class="rounded-xl bg-gradient-to-r from-teal-500/10 to-teal-500/10 border border-teal-500/20 p-8 text-center">
+            <div class="w-14 h-14 bg-gradient-to-br from-teal-500 to-teal-500 rounded-full flex items-center justify-center mx-auto mb-4">
                 <i class="fas fa-book-open text-white text-xl" aria-hidden="true"></i>
             </div>
             <h3 class="text-xl font-bold mb-2 text-gray-900 dark:text-white">Prefer to Read Everything at Once?</h3>
@@ -97,7 +97,7 @@
                 <span><i class="fas fa-list mr-1" aria-hidden="true"></i>{seriesParts.length} parts combined</span>
             </div>
             <a href="/series/full-series"
-               class="inline-flex items-center bg-gradient-to-r from-blue-600 to-blue-600 hover:from-blue-700 hover:to-blue-700 text-white px-8 py-3 rounded-full transition font-medium shadow-lg">
+               class="inline-flex items-center bg-gradient-to-r from-teal-600 to-teal-600 hover:from-teal-700 hover:to-teal-700 text-white px-8 py-3 rounded-full transition font-medium shadow-lg">
                 <i class="fas fa-book-open mr-2" aria-hidden="true"></i>Read Full Series
             </a>
         </div>
@@ -116,17 +116,17 @@
 
         <div class="grid gap-4">
             {#each seriesParts as part}
-                <article class="group rounded-xl border border-gray-200 dark:border-gray-700/50 bg-white dark:bg-gray-800/50 hover:border-blue-500/50 hover:shadow-lg hover:shadow-blue-500/5 transition-all duration-200 overflow-hidden">
+                <article class="group rounded-xl border border-gray-200 dark:border-gray-700/50 bg-white dark:bg-gray-800/50 hover:border-teal-500/50 hover:shadow-lg hover:shadow-teal-500/5 transition-all duration-200 overflow-hidden">
                     <div class="p-6">
                         <div class="flex flex-nowrap min-w-0 items-center gap-3 mb-3">
-                            <span class="bg-blue-500/10 text-blue-600 dark:text-blue-400 px-3 py-1 rounded-full text-sm font-medium whitespace-nowrap">
+                            <span class="bg-teal-500/10 text-teal-600 dark:text-teal-400 px-3 py-1 rounded-full text-sm font-medium whitespace-nowrap">
                                 Part {part.part}
                             </span>
                             <span class="text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
                                 <i class="fas fa-clock mr-1" aria-hidden="true"></i>{part.readTime}
                             </span>
                             {#if part.status === 'published'}
-                                <span class="bg-blue-500/10 text-blue-600 dark:text-blue-400 px-2 py-1 rounded text-xs font-medium whitespace-nowrap">
+                                <span class="bg-teal-500/10 text-teal-600 dark:text-teal-400 px-2 py-1 rounded text-xs font-medium whitespace-nowrap">
                                     Published
                                 </span>
                             {:else}
@@ -138,7 +138,7 @@
 
                         <h3 class="text-xl font-bold mb-2 text-gray-900 dark:text-white leading-tight">
                             {#if part.status === 'published'}
-                                <a href="/series/{part.slug}" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+                                <a href="/series/{part.slug}" class="hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
                                     {part.title}
                                 </a>
                             {:else}
@@ -152,7 +152,7 @@
 
                         {#if part.status === 'published'}
                             <a href="/series/{part.slug}"
-                               class="inline-flex min-h-[44px] items-center text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium transition-colors text-sm">
+                               class="inline-flex min-h-[44px] items-center text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300 font-medium transition-colors text-sm">
                                 Read Part {part.part}
                                 <i class="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform" aria-hidden="true"></i>
                             </a>
@@ -177,11 +177,11 @@
         </p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
             <a href="/series/part-1-can-you-build-with-ai"
-               class="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 rounded-full font-medium transition shadow-lg shadow-blue-600/25">
+               class="bg-teal-600 hover:bg-teal-700 text-white px-8 py-3 rounded-full font-medium transition shadow-lg shadow-teal-600/25">
                 <i class="fas fa-play mr-2" aria-hidden="true"></i>Start with Part 1
             </a>
             <a href="/series/full-series"
-               class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-blue-500 hover:text-blue-600 dark:hover:text-blue-400 px-8 py-3 rounded-full font-medium transition">
+               class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-teal-500 hover:text-teal-600 dark:hover:text-teal-400 px-8 py-3 rounded-full font-medium transition">
                 <i class="fas fa-book-open mr-2" aria-hidden="true"></i>Read All Parts
             </a>
         </div>

--- a/src/routes/series/full-series/+page.svelte
+++ b/src/routes/series/full-series/+page.svelte
@@ -189,7 +189,7 @@
             {#each fullTOC as item}
                 <button
                     on:click={() => scrollToSection(item.id)}
-                    class="block w-full text-left text-xs py-1 px-2 rounded transition-colors hover:bg-gray-100 dark:hover:bg-gray-700 {activeSectionId === item.id ? 'bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300' : 'text-gray-600 dark:text-gray-400'}"
+                    class="block w-full text-left text-xs py-1 px-2 rounded transition-colors hover:bg-gray-100 dark:hover:bg-gray-700 {activeSectionId === item.id ? 'bg-teal-100 dark:bg-teal-900 text-teal-700 dark:text-teal-300' : 'text-gray-600 dark:text-gray-400'}"
                     class:pl-2={item.level === 1}
                     class:pl-4={item.level === 2}
                     class:font-semibold={item.level === 1}
@@ -202,15 +202,15 @@
 {/if}
 
 <!-- Hero Section -->
-<section class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 py-16">
+<section class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 py-16">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center">
             <div class="mb-6">
-                <a href="/series" class="inline-flex min-h-[44px] items-center text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium">
+                <a href="/series" class="inline-flex min-h-[44px] items-center text-teal-600 hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300 font-medium">
                     ← Back to Series Overview
                 </a>
             </div>
-            <div class="mb-4 inline-flex items-center rounded-lg bg-blue-50 dark:bg-blue-900/30 px-4 py-2 text-blue-800 dark:text-blue-300">
+            <div class="mb-4 inline-flex items-center rounded-lg bg-teal-50 dark:bg-teal-900/30 px-4 py-2 text-teal-800 dark:text-teal-300">
                 <i class="fas fa-book-open mr-2" aria-hidden="true"></i>
                 <span class="font-medium">Complete Series — 10 Parts</span>
             </div>
@@ -232,8 +232,8 @@
 
 <!-- Series Info Box -->
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
-        <p class="text-blue-800 dark:text-blue-200 mb-0">
+    <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-800 rounded-lg p-6">
+        <p class="text-teal-800 dark:text-teal-200 mb-0">
             <strong>About this article:</strong> This is the complete, merged version of the 10-part "How I Built MiniBreaks.io With AI" series. Each part is presented in order below. You can use the floating table of contents (desktop) to navigate between sections.
         </p>
     </div>
@@ -243,15 +243,15 @@
 <!-- PART 1: Can You Really Build a Website with AI? -->
 <!-- ============================================================ -->
 <section id="part-1" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 1 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 1 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Can You Really Build a Website with AI?</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">10 min read</p>
     </div>
 
     <div class="prose prose-lg max-w-none dark:prose-invert">
         <p class="text-xl leading-relaxed text-gray-600 dark:text-gray-300 mb-8">
-            Welcome to my exploration of building <a href="https://minibreaks.io" target="_blank" class="text-blue-600 underline decoration-2 underline-offset-2 transition-colors hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">MiniBreaks.io</a> with AI. A story of me trying to build a complete website using artificial intelligence as my development partner.
+            Welcome to my exploration of building <a href="https://minibreaks.io" target="_blank" class="text-teal-600 underline decoration-2 underline-offset-2 transition-colors hover:text-teal-800 dark:text-teal-400 dark:hover:text-teal-300">MiniBreaks.io</a> with AI. A story of me trying to build a complete website using artificial intelligence as my development partner.
         </p>
 
         <section id="the-big-question">
@@ -263,7 +263,7 @@
                 The short answer is <strong>yes</strong>. The longer answer? It's not as magical or automatic as it sounds. As someone with years of experience in software engineering, I already had a good sense of what needed to happen—but even for me, the process wasn't exactly plug-and-play.
             </p>
 
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
                 <p class="mb-0 text-gray-700 dark:text-gray-300">
                     <strong>Here's the thing:</strong> AI is incredibly powerful, but it's not a magic wand. It's more like having a really smart assistant who knows a lot about coding but still needs clear direction from you.
                 </p>
@@ -329,14 +329,14 @@
 
             <div class="my-8 space-y-6">
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"><i class="fas fa-tools text-blue-600 dark:text-blue-300" aria-hidden="true"></i></div>
+                    <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"><i class="fas fa-tools text-teal-600 dark:text-teal-300" aria-hidden="true"></i></div>
                     <div>
                         <h4 class="mb-2 font-bold text-gray-900 dark:text-white">The Right (Minimum) Tools for the Job</h4>
                         <p class="text-gray-600 dark:text-gray-400">Which AI tools work best for different tasks, from GitHub Copilot for coding to ChatGPT for planning.</p>
                     </div>
                 </div>
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"><i class="fas fa-comment-dots text-blue-600 dark:text-blue-300" aria-hidden="true"></i></div>
+                    <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"><i class="fas fa-comment-dots text-teal-600 dark:text-teal-300" aria-hidden="true"></i></div>
                     <div>
                         <h4 class="mb-2 font-bold text-gray-900 dark:text-white">Writing Effective Prompts</h4>
                         <p class="text-gray-600 dark:text-gray-400">How to communicate with AI tools to get exactly what you need, not overwhelming lists of possibilities.</p>
@@ -350,7 +350,7 @@
                     </div>
                 </div>
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"><i class="fas fa-handshake text-blue-600 dark:text-blue-300"></i></div>
+                    <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"><i class="fas fa-handshake text-teal-600 dark:text-teal-300"></i></div>
                     <div>
                         <h4 class="mb-2 font-bold text-gray-900 dark:text-white">Making AI Your Partner</h4>
                         <p class="text-gray-600 dark:text-gray-400">Most importantly, how to work with AI as a collaborative partner rather than expecting it to do everything for you.</p>
@@ -364,12 +364,12 @@
             <p>Whether you're a complete beginner who's never written a line of code, or someone with technical experience who wants to see how AI can accelerate your workflow, this series is designed to be accessible and practical.</p>
             <p>I'll explain technical concepts in plain language, show you exactly which buttons to click, and most importantly, share the real challenges I faced and how I overcame them.</p>
 
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
                 <div class="flex items-start space-x-3">
-                    <i class="fas fa-lightbulb mt-1 text-blue-600 dark:text-blue-400"></i>
+                    <i class="fas fa-lightbulb mt-1 text-teal-600 dark:text-teal-400"></i>
                     <div>
-                        <p class="mb-2 font-semibold text-blue-800 dark:text-blue-300">My Promise to You</p>
-                        <p class="mb-0 text-blue-700 dark:text-blue-400">No jargon without explanation. No skipped steps. No "and then magic happens" moments. Just honest, practical guidance from someone who's been through the process.</p>
+                        <p class="mb-2 font-semibold text-teal-800 dark:text-teal-300">My Promise to You</p>
+                        <p class="mb-0 text-teal-700 dark:text-teal-400">No jargon without explanation. No skipped steps. No "and then magic happens" moments. Just honest, practical guidance from someone who's been through the process.</p>
                     </div>
                 </div>
             </div>
@@ -393,8 +393,8 @@
 <!-- PART 2: Why I Wanted to Use AI -->
 <!-- ============================================================ -->
 <section id="part-2" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 2 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 2 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Why I Wanted to Use AI</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">8 min read</p>
     </div>
@@ -447,12 +447,12 @@
             <p>But let's be honest: it wasn't hands-off magic. AI required careful direction, clear communication, and constant quality control. There were moments of frustration when AI would misunderstand requirements or generate code that looked right but had subtle bugs.</p>
             <p>I learned that AI amplifies both good and bad practices. If I was unclear in my instructions, I got unclear results. If I didn't understand the problem space well enough, AI couldn't compensate for that gap.</p>
 
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
                 <div class="flex items-start space-x-3">
-                    <i class="fas fa-lightbulb mt-1 text-blue-600 dark:text-blue-400" aria-hidden="true"></i>
+                    <i class="fas fa-lightbulb mt-1 text-teal-600 dark:text-teal-400" aria-hidden="true"></i>
                     <div>
-                        <p class="mb-2 font-semibold text-blue-800 dark:text-blue-300">Key Lesson</p>
-                        <p class="mb-0 text-blue-700 dark:text-blue-400">I need to get my requirements right before asking AI to implement them.</p>
+                        <p class="mb-2 font-semibold text-teal-800 dark:text-teal-300">Key Lesson</p>
+                        <p class="mb-0 text-teal-700 dark:text-teal-400">I need to get my requirements right before asking AI to implement them.</p>
                     </div>
                 </div>
             </div>
@@ -465,7 +465,7 @@
             <p>Therefore, I want you to ask yourself a few questions before we continue with the series:</p>
 
             <h3 id="reflection-questions">Questions for You</h3>
-            <div class="my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+            <div class="my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
                 <ul class="space-y-3">
                     <li><strong>What do you want AI to do for you?</strong> Be specific. Is it about speed? Learning? Handling tasks you find tedious?</li>
                     <li><strong>How much are you expecting AI to do for you?</strong> 20% of the work? 50%? 80%? What would success look like?</li>
@@ -494,8 +494,8 @@
 <!-- PART 3: Choosing Your Tools & Setting Up -->
 <!-- ============================================================ -->
 <section id="part-3" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 3 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 3 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Choosing Your Tools & Setting Up</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">12 min read</p>
     </div>
@@ -513,26 +513,26 @@
             <p>After trying dozens of AI tools, I've narrowed it down to these four essentials. Each serves a specific purpose, and together they create a powerful development workflow:</p>
 
             <div class="not-prose my-8 grid grid-cols-1 gap-6 md:grid-cols-2">
-                <div class="rounded-lg border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                    <h4 class="mb-2 font-bold text-blue-700 dark:text-blue-300">💬 ChatGPT</h4>
+                <div class="rounded-lg border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                    <h4 class="mb-2 font-bold text-teal-700 dark:text-teal-300">💬 ChatGPT</h4>
                     <p class="text-sm text-gray-600 dark:text-gray-400">Your AI brainstorming partner and problem solver</p>
                 </div>
                 <div class="rounded-lg border-l-4 border-green-500 bg-green-50 p-6 dark:bg-green-900/20">
                     <h4 class="mb-2 font-bold text-green-700 dark:text-green-300">⚡ GitHub Copilot/Cursor</h4>
                     <p class="text-sm text-gray-600 dark:text-gray-400">Your AI coding assistant that writes code as you instruct it</p>
                 </div>
-                <div class="rounded-lg border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                    <h4 class="mb-2 font-bold text-blue-700 dark:text-blue-300">🤗 Hugging Face</h4>
+                <div class="rounded-lg border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                    <h4 class="mb-2 font-bold text-teal-700 dark:text-teal-300">🤗 Hugging Face</h4>
                     <p class="text-sm text-gray-600 dark:text-gray-400">Free AI models for advanced features such as designing (optional)</p>
                 </div>
-                <div class="rounded-lg border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                    <h4 class="mb-2 font-bold text-blue-700 dark:text-blue-300">📁 GitHub</h4>
+                <div class="rounded-lg border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                    <h4 class="mb-2 font-bold text-teal-700 dark:text-teal-300">📁 GitHub</h4>
                     <p class="text-sm text-gray-600 dark:text-gray-400">Where your code lives and how you deploy your site</p>
                 </div>
             </div>
 
             <h3 id="chatgpt">ChatGPT - Your AI Assistant</h3>
-            <div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-4 dark:bg-blue-900/20">
+            <div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-4 dark:bg-teal-900/20">
                 <p class="mb-0 text-gray-700 dark:text-gray-300"><strong>Think of ChatGPT as your patient mentor who never gets tired of explaining things.</strong></p>
             </div>
             <p>ChatGPT will be your primary brainstorming partner. Here's how I use it:</p>
@@ -549,7 +549,7 @@
 
             <h3 id="cursor">Cursor IDE - AI-First Code Editor</h3>
             <p>Cursor is like a supercharged code editor built specifically for AI assistance. It's what I used to kick off MiniBreaks.io, and it's <strong>completely free</strong>.</p>
-            <div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-4 dark:bg-blue-900/20">
+            <div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-4 dark:bg-teal-900/20">
                 <p class="mb-0 text-gray-700 dark:text-gray-300"><strong>My recommendation:</strong> Start with Cursor (free), do as much as you can in the first 2 weeks, and add GitHub Copilot later if you want even more AI assistance.</p>
             </div>
 
@@ -590,7 +590,7 @@
             <div class="not-prose my-6 rounded-lg bg-gray-50 p-6 dark:bg-gray-800">
                 <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
                     <div class="text-center">
-                        <div class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"><span class="font-bold text-blue-600 dark:text-blue-300">1</span></div>
+                        <div class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"><span class="font-bold text-teal-600 dark:text-teal-300">1</span></div>
                         <h4 class="mb-1 font-bold text-gray-900 dark:text-white">Plan with ChatGPT</h4>
                         <p class="text-sm text-gray-600 dark:text-gray-400">Brainstorm and plan your feature</p>
                     </div>
@@ -600,7 +600,7 @@
                         <p class="text-sm text-gray-600 dark:text-gray-400">Write code with AI assistance</p>
                     </div>
                     <div class="text-center">
-                        <div class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"><span class="font-bold text-blue-600 dark:text-blue-300">3</span></div>
+                        <div class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"><span class="font-bold text-teal-600 dark:text-teal-300">3</span></div>
                         <h4 class="mb-1 font-bold text-gray-900 dark:text-white">Deploy to GitHub</h4>
                         <p class="text-sm text-gray-600 dark:text-gray-400">Push your changes live</p>
                     </div>
@@ -612,11 +612,11 @@
             <h2>Your Homework</h2>
             <p>Before we move to the next part, complete these simple setup tasks:</p>
             <div class="my-6 space-y-4">
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Create your GitHub account and first repository</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Download and install Visual Studio Code</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Sign up for GitHub Copilot (start your free trial)</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Sign up for ChatGPT (free account is fine)</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Install Git to connect your computer to GitHub</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Create your GitHub account and first repository</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Download and install Visual Studio Code</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Sign up for GitHub Copilot (start your free trial)</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Sign up for ChatGPT (free account is fine)</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Install Git to connect your computer to GitHub</span></div>
             </div>
             <div class="not-prose my-6 border-l-4 border-yellow-500 bg-yellow-50 p-4 dark:bg-yellow-900/20">
                 <p class="mb-0 text-gray-700 dark:text-gray-300"><strong>⚠️ Important about Cursor:</strong> If you've never registered for Cursor before, do NOT register yet! Wait until Part 5 so you can take advantage of the 2-week trial when you actually start coding.</p>
@@ -629,8 +629,8 @@
 <!-- PART 4: Crafting Your Idea & MVP with AI -->
 <!-- ============================================================ -->
 <section id="part-4" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 4 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 4 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Crafting Your Idea & MVP with AI</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">10 min read</p>
     </div>
@@ -664,7 +664,7 @@
             <p>When you brainstorm your website idea with AI, keep these principles in mind:</p>
             <div class="not-prose my-8 space-y-6">
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">1</div>
+                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">1</div>
                     <div>
                         <h4 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white" id="mvp-focus">Make it clear you want an MVP</h4>
                         <p class="text-gray-700 dark:text-gray-300">Tell AI explicitly that you're looking for a Minimum Viable Product. This keeps the scope small and achievable.</p>
@@ -678,7 +678,7 @@
                     </div>
                 </div>
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">3</div>
+                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">3</div>
                     <div>
                         <h4 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white" id="business-needs">Focus on business needs</h4>
                         <p class="text-gray-700 dark:text-gray-300">If you don't frame your request around business needs, AI will behave like an overanxious parent — giving you way more technical details than you need at this stage.</p>
@@ -692,7 +692,7 @@
             <p>If you're using the paid version of ChatGPT, create a Project for this brainstorming session.</p>
             <img src="/ai-series/new-chatgpt-project.jpg" alt="ChatGPT Projects Setup" loading="lazy" class="my-6 w-full max-w-md sm:max-w-lg md:max-w-xl lg:max-w-2xl rounded-lg shadow-lg object-cover">
             <p>Why? Because you can define the tone and role AI should play for you.</p>
-            <div class="not-prose my-6 rounded-lg bg-blue-50 p-6 dark:bg-blue-900/20">
+            <div class="not-prose my-6 rounded-lg bg-teal-50 p-6 dark:bg-teal-900/20">
                 <p class="mb-0 text-gray-700 dark:text-gray-300"><strong>Project Instructions:</strong><br>"I'd like you to act as my co-founder and brainstorming partner. Please focus on creative yet practical business ideas for a new website, aiming for MVP."</p>
             </div>
         </section>
@@ -726,13 +726,13 @@
         <section id="p4-homework">
             <h2>Your Homework</h2>
             <div class="my-6 space-y-4">
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Set up a ChatGPT Project for your website brainstorming</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Write down 3 different website ideas you're considering</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>For each idea, brainstorm with AI using the 3 guidelines</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Choose ONE idea and write your MVP in exactly one paragraph</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Cross-reference your MVP with a second AI tool</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Set up a ChatGPT Project for your website brainstorming</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Write down 3 different website ideas you're considering</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>For each idea, brainstorm with AI using the 3 guidelines</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Choose ONE idea and write your MVP in exactly one paragraph</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Cross-reference your MVP with a second AI tool</span></div>
             </div>
-            <div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-4 dark:bg-blue-900/20">
+            <div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-4 dark:bg-teal-900/20">
                 <p class="mb-0 text-gray-700 dark:text-gray-300"><strong>📝 Example MVP:</strong> "MiniBreaks.io is a playful website encourages taking mindful breaks, promotes workplace well-being, and fosters a sense of fun through achievements and leaderboards."</p>
             </div>
         </section>
@@ -743,8 +743,8 @@
 <!-- PART 5: Designing Your UI/UX with AI -->
 <!-- ============================================================ -->
 <section id="part-5" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 5 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 5 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Designing Your UI/UX with AI</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">12 min read</p>
     </div>
@@ -759,9 +759,9 @@
             <h2>Introducing DeepSite</h2>
             <p>DeepSite is available at: <a href="https://huggingface.co/spaces/enzostvs/deepsite" target="_blank" rel="noopener">https://huggingface.co/spaces/enzostvs/deepsite</a></p>
             <p>This is completely free, but with very limited number of uses. But if you get your prompt right, you should get what you want with one or two attempts.</p>
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                <p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">Keep in mind:</p>
-                <p class="mb-0 text-blue-700 dark:text-blue-300">This HuggingFace workspace does not build a complete website. Instead, it generates a beautifully designed landing page (homepage) to serve as the foundation of your site's design system.</p>
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                <p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">Keep in mind:</p>
+                <p class="mb-0 text-teal-700 dark:text-teal-300">This HuggingFace workspace does not build a complete website. Instead, it generates a beautifully designed landing page (homepage) to serve as the foundation of your site's design system.</p>
             </div>
         </section>
 
@@ -801,7 +801,7 @@
             <h2>Technical Notes</h2>
             <div class="not-prose my-6 space-y-4">
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">1</div>
+                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">1</div>
                     <div><p class="text-gray-700 dark:text-gray-300">It uses <strong>Tailwind CSS v3</strong>, a popular utility-based framework for styling. Tailwind v4 exists now, but v3 is still perfectly fine for a prototype.</p></div>
                 </div>
                 <div class="flex items-start space-x-4">
@@ -814,9 +814,9 @@
         <section id="p5-homework">
             <h2>Your Homework</h2>
             <div class="my-6 space-y-4">
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Visit the DeepSite workspace and generate a homepage for your own idea</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Iterate on your prompt if needed</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Once happy, copy the source code and save it as <code>generated.html</code></span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Visit the DeepSite workspace and generate a homepage for your own idea</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Iterate on your prompt if needed</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Once happy, copy the source code and save it as <code>generated.html</code></span></div>
             </div>
         </section>
     </div>
@@ -826,8 +826,8 @@
 <!-- PART 6: Writing Code with AI Assistance -->
 <!-- ============================================================ -->
 <section id="part-6" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 6 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 6 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Writing Code with AI Assistance</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">15 min read</p>
     </div>
@@ -841,9 +841,9 @@
         <section id="choosing-tech-stack">
             <h2>🧰 Choosing Your Tech Stack</h2>
             <p>Before diving in, you'll need to pick a tech stack — which simply means the combination of technologies you'll use to build your website.</p>
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                <p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">Why not just stick with vanilla JavaScript?</p>
-                <p class="mb-0 text-blue-700 dark:text-blue-300">Vanilla JavaScript works great for adding simple user interactions, animations, and maintaining user state. However, as your website grows, it becomes hard to maintain and scale.</p>
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                <p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">Why not just stick with vanilla JavaScript?</p>
+                <p class="mb-0 text-teal-700 dark:text-teal-300">Vanilla JavaScript works great for adding simple user interactions, animations, and maintaining user state. However, as your website grows, it becomes hard to maintain and scale.</p>
             </div>
             <p>My recommendations: <strong>SvelteKit</strong> for frontend, <strong>Tailwind</strong> for CSS, <strong>PostgreSQL</strong> for database (when needed later).</p>
 
@@ -891,8 +891,8 @@
         <section id="first-ai-prompt">
             <h2>🤖 Your First AI Prompt</h2>
             <p>Now it's time to let AI help you turn that static HTML into a proper SvelteKit site.</p>
-            <div class="not-prose my-6 rounded-lg bg-gray-100 p-6 dark:bg-gray-800 border-l-4 border-blue-500">
-                <div class="mb-3 flex items-center"><i class="fas fa-robot mr-2 text-blue-600 dark:text-blue-400" aria-hidden="true"></i><span class="font-semibold text-gray-900 dark:text-white">AI Prompt Template</span></div>
+            <div class="not-prose my-6 rounded-lg bg-gray-100 p-6 dark:bg-gray-800 border-l-4 border-teal-500">
+                <div class="mb-3 flex items-center"><i class="fas fa-robot mr-2 text-teal-600 dark:text-teal-400" aria-hidden="true"></i><span class="font-semibold text-gray-900 dark:text-white">AI Prompt Template</span></div>
                 <div class="text-sm text-gray-700 dark:text-gray-300 font-mono bg-white dark:bg-gray-900 p-4 rounded border">Use generated.html as reference. Migrate this page into SvelteKit.<br><br>- Break the page into separate components: header, footer, hero, and other sections.<br>- Convert all JavaScript to TypeScript.<br>- Ensure components are reusable.<br>- Create at least one additional page (e.g., About) using the same design system.</div>
             </div>
 
@@ -904,9 +904,9 @@
                 <li>Reusable components in <code>src/lib/components/</code></li>
                 <li>All JavaScript converted to TypeScript</li>
             </ul>
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                <p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">✨ The Magic Moment</p>
-                <p class="mb-0 text-blue-700 dark:text-blue-300">You now have a structured, maintainable project with a home page, an about page, and reusable components — making it easy for AI (and you) to expand further.</p>
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                <p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">✨ The Magic Moment</p>
+                <p class="mb-0 text-teal-700 dark:text-teal-300">You now have a structured, maintainable project with a home page, an about page, and reusable components — making it easy for AI (and you) to expand further.</p>
             </div>
 
             <h3 id="extending-with-ai">Extending Your Site with AI</h3>
@@ -920,7 +920,7 @@
             <h2>🎯 Best Practices for AI-Assisted Coding</h2>
             <div class="my-8 space-y-6">
                 <div class="rounded-lg border border-gray-200 p-6 dark:border-gray-700 dark:bg-gray-800">
-                    <h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white"><i class="fas fa-code mr-3 text-blue-500" aria-hidden="true"></i>Be Specific with Context</h4>
+                    <h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white"><i class="fas fa-code mr-3 text-teal-500" aria-hidden="true"></i>Be Specific with Context</h4>
                     <p class="text-gray-700 dark:text-gray-300">Always include relevant files in your AI context. The more context AI has about your existing code structure, the better it can maintain consistency.</p>
                 </div>
                 <div class="rounded-lg border border-gray-200 p-6 dark:border-gray-700 dark:bg-gray-800">
@@ -928,7 +928,7 @@
                     <p class="text-gray-700 dark:text-gray-300">Instead of asking AI to build an entire feature, break it into smaller components. Ask for one component at a time, then integrate them.</p>
                 </div>
                 <div class="rounded-lg border border-gray-200 p-6 dark:border-gray-700 dark:bg-gray-800">
-                    <h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white"><i class="fas fa-sync-alt mr-3 text-blue-500" aria-hidden="true"></i>Iterate and Refine</h4>
+                    <h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white"><i class="fas fa-sync-alt mr-3 text-teal-500" aria-hidden="true"></i>Iterate and Refine</h4>
                     <p class="text-gray-700 dark:text-gray-300">Don't expect perfection on the first try. Use follow-up prompts to refine styling, improve accessibility, or add missing functionality.</p>
                 </div>
             </div>
@@ -937,11 +937,11 @@
         <section id="p6-homework">
             <h2>📝 Homework</h2>
             <div class="my-6 space-y-4">
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Install Node.js and Git on your computer</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Create a SvelteKit project using the CLI</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Move your generated.html into the project folder</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Use the AI prompt above to convert your page to SvelteKit</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Open your project in a browser (<code>npm run dev</code>) and explore the result!</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Install Node.js and Git on your computer</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Create a SvelteKit project using the CLI</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Move your generated.html into the project folder</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Use the AI prompt above to convert your page to SvelteKit</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Open your project in a browser (<code>npm run dev</code>) and explore the result!</span></div>
             </div>
         </section>
     </div>
@@ -951,8 +951,8 @@
 <!-- PART 7: Adding Advanced Features with AI -->
 <!-- ============================================================ -->
 <section id="part-7" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 7 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 7 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Adding Advanced Features with AI</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">15 min read</p>
     </div>
@@ -975,7 +975,7 @@
             <p>Think of a database as a digital notebook that stores all your website's important information neatly organized into tables. Each table is like a spreadsheet with rows and columns.</p>
             <div class="not-prose my-6 space-y-4">
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold"><i class="fas fa-table" aria-hidden="true"></i></div>
+                    <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold"><i class="fas fa-table" aria-hidden="true"></i></div>
                     <div><h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Table</h4><p class="text-gray-700 dark:text-gray-300">Like a sheet in Excel where you store related information.</p></div>
                 </div>
                 <div class="flex items-start space-x-4">
@@ -983,7 +983,7 @@
                     <div><h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Column</h4><p class="text-gray-700 dark:text-gray-300">Like headings on your sheet (e.g., username, password, email).</p></div>
                 </div>
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold"><i class="fas fa-grip-lines-vertical" aria-hidden="true"></i></div>
+                    <div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold"><i class="fas fa-grip-lines-vertical" aria-hidden="true"></i></div>
                     <div><h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Row</h4><p class="text-gray-700 dark:text-gray-300">Each individual record (each user's data).</p></div>
                 </div>
             </div>
@@ -1033,14 +1033,14 @@ CREATE TABLE users (
 
             <h3 id="login-page">Step 2: Login Page</h3>
             <div class="not-prose my-8 rounded-lg bg-gray-100 p-6 dark:bg-gray-800">
-                <div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-blue-500">
+                <div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-teal-500">
                     <p class="text-gray-700 dark:text-gray-300 italic">"Create a basic login page where users can enter their username and password to log in. Include a 'Remember me' checkbox and a link to password recovery."</p>
                 </div>
             </div>
 
             <h3 id="password-recovery">Step 3: Password Recovery Page</h3>
             <div class="not-prose my-8 rounded-lg bg-gray-100 p-6 dark:bg-gray-800">
-                <div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-blue-500">
+                <div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-teal-500">
                     <p class="text-gray-700 dark:text-gray-300 italic">"Create a page that lets users recover their password by entering their email. For now, just create the form and logic, but leave the email sending functionality as a placeholder."</p>
                 </div>
             </div>
@@ -1080,7 +1080,7 @@ CREATE TABLE users (
                     </ul>
                 </div>
                 <div class="rounded-lg border border-gray-200 p-6 dark:border-gray-700 dark:bg-gray-800">
-                    <h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white"><i class="fas fa-shield-alt mr-3 text-blue-500" aria-hidden="true"></i>API Key Security</h4>
+                    <h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white"><i class="fas fa-shield-alt mr-3 text-teal-500" aria-hidden="true"></i>API Key Security</h4>
                     <ul class="space-y-2 text-gray-700 dark:text-gray-300">
                         <li>Store API keys in environment variables</li>
                         <li>Never commit API keys to version control</li>
@@ -1093,10 +1093,10 @@ CREATE TABLE users (
         <section id="p7-homework">
             <h2>📓 Homework</h2>
             <div class="my-6 space-y-4">
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Install PostgreSQL, create your database and user table</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Generate signup and login pages using AI prompts</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Create the password recovery page</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Sign up for Brevo and use AI to connect email functionality</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Install PostgreSQL, create your database and user table</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Generate signup and login pages using AI prompts</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Create the password recovery page</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Sign up for Brevo and use AI to connect email functionality</span></div>
             </div>
         </section>
     </div>
@@ -1106,8 +1106,8 @@ CREATE TABLE users (
 <!-- PART 8: Before Deployment: Testing & Preparation -->
 <!-- ============================================================ -->
 <section id="part-8" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 8 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 8 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Before Deployment: Testing & Preparation</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">12 min read</p>
     </div>
@@ -1136,9 +1136,9 @@ CREATE TABLE users (
             </div>
 
             <h3 id="debugging-with-ai">Debugging with AI Assistance</h3>
-            <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6 my-6">
-                <h4 class="text-lg font-semibold text-blue-800 dark:text-blue-200 mb-3"><i class="fas fa-lightbulb mr-2" aria-hidden="true"></i>AI Debugging Prompt Template</h4>
-                <p class="text-blue-700 dark:text-blue-300">"This [page/feature] isn't working as expected. Here's what I'm seeing: [describe the issue clearly]. Can you help me write a console log to identify the issue?"</p>
+            <div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-800 rounded-lg p-6 my-6">
+                <h4 class="text-lg font-semibold text-teal-800 dark:text-teal-200 mb-3"><i class="fas fa-lightbulb mr-2" aria-hidden="true"></i>AI Debugging Prompt Template</h4>
+                <p class="text-teal-700 dark:text-teal-300">"This [page/feature] isn't working as expected. Here's what I'm seeing: [describe the issue clearly]. Can you help me write a console log to identify the issue?"</p>
             </div>
 
             <h3 id="automation-testing">Automation Testing (Optional)</h3>
@@ -1256,12 +1256,12 @@ CREATE TABLE users (
         <section id="p8-homework">
             <h2>📋 Homework</h2>
             <div class="my-6 space-y-4">
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span><strong>Manual Testing:</strong> Verify all functionality works locally</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span><strong>Security:</strong> Apply at least two recommended security practices</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span><strong>Accessibility:</strong> Use the Accessibility Insights extension for an audit</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span><strong>Performance:</strong> Run Lighthouse and boost your score above 80</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span><strong>SEO:</strong> Implement basic SEO improvements</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span><strong>Deploy:</strong> Ask AI for deployment guidance and deploy your MVP</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span><strong>Manual Testing:</strong> Verify all functionality works locally</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span><strong>Security:</strong> Apply at least two recommended security practices</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span><strong>Accessibility:</strong> Use the Accessibility Insights extension for an audit</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span><strong>Performance:</strong> Run Lighthouse and boost your score above 80</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span><strong>SEO:</strong> Implement basic SEO improvements</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span><strong>Deploy:</strong> Ask AI for deployment guidance and deploy your MVP</span></div>
             </div>
         </section>
     </div>
@@ -1271,8 +1271,8 @@ CREATE TABLE users (
 <!-- PART 9: Lessons Learned from AI-Assisted Development -->
 <!-- ============================================================ -->
 <section id="part-9" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 9 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 9 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">Lessons Learned from Building with AI</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">9 min read</p>
     </div>
@@ -1301,9 +1301,9 @@ CREATE TABLE users (
 
             <h3 id="overcomplicated-code">Overcomplicated Code</h3>
             <p>AI sometimes generates overly complex solutions when a simpler approach would work.</p>
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                <p class="mb-2 font-medium text-blue-800 dark:text-blue-200">💡 Keep it simple:</p>
-                <p class="text-blue-700 dark:text-blue-300">Always ask yourself: "Is there a simpler way to do this?" If the AI-generated code feels overly complex, ask it to simplify.</p>
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                <p class="mb-2 font-medium text-teal-800 dark:text-teal-200">💡 Keep it simple:</p>
+                <p class="text-teal-700 dark:text-teal-300">Always ask yourself: "Is there a simpler way to do this?" If the AI-generated code feels overly complex, ask it to simplify.</p>
             </div>
 
             <h3 id="wrong-assumptions">Wrong Assumptions</h3>
@@ -1320,17 +1320,17 @@ CREATE TABLE users (
                 <p class="text-gray-700 dark:text-gray-300"><strong>Root Cause:</strong> The issue wasn't in the component — it was a timing conflict between the backdrop click handler and the button click handler. The AI kept changing the component structure because it didn't have enough context about event propagation.</p>
                 <p class="text-gray-700 dark:text-gray-300 mt-4"><strong>Solution:</strong> I stopped the AI, looked at the event flow myself, added <code>event.stopPropagation()</code> to the Cancel button, and it worked instantly.</p>
             </div>
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                <p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">🎓 Takeaway</p>
-                <p class="text-blue-700 dark:text-blue-300">When AI keeps failing to fix an issue, step back and try to understand the root cause yourself. AI is great at generating code, but debugging often requires a higher-level understanding of how pieces fit together.</p>
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                <p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">🎓 Takeaway</p>
+                <p class="text-teal-700 dark:text-teal-300">When AI keeps failing to fix an issue, step back and try to understand the root cause yourself. AI is great at generating code, but debugging often requires a higher-level understanding of how pieces fit together.</p>
             </div>
 
             <h3 id="deployment-case-study">Case Study 2: Deployment Troubleshooting</h3>
             <p>After weeks of development, I was ready to deploy MiniBreaks.io. The AI suggested using a popular deployment platform and provided step-by-step instructions. Everything seemed fine — until I pushed my code and got a build error.</p>
             <p>The AI tried to fix the error by modifying the build configuration, but each fix introduced new issues. It took me hours of back-and-forth before I realized the root cause: my Node.js version was incompatible with one of my dependencies.</p>
-            <div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-                <p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">🎓 Takeaway</p>
-                <p class="text-blue-700 dark:text-blue-300">Always check your environment configuration (Node.js version, dependencies) before troubleshooting code-level issues. Version mismatches are a common source of deployment problems.</p>
+            <div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+                <p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">🎓 Takeaway</p>
+                <p class="text-teal-700 dark:text-teal-300">Always check your environment configuration (Node.js version, dependencies) before troubleshooting code-level issues. Version mismatches are a common source of deployment problems.</p>
             </div>
         </section>
 
@@ -1362,9 +1362,9 @@ CREATE TABLE users (
         <section id="p9-homework">
             <h2>📓 Homework</h2>
             <div class="my-6 space-y-4">
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Review your project and identify at least two issues where AI guidance wasn't accurate</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Document your own "case study" of a problem you solved differently from what AI suggested</span></div>
-                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled /><span>Write down three things AI did well and three areas where it fell short</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Review your project and identify at least two issues where AI guidance wasn't accurate</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Document your own "case study" of a problem you solved differently from what AI suggested</span></div>
+                <div class="flex items-start space-x-3"><input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled /><span>Write down three things AI did well and three areas where it fell short</span></div>
             </div>
         </section>
     </div>
@@ -1374,8 +1374,8 @@ CREATE TABLE users (
 <!-- PART 10: The Future of AI-Assisted Development -->
 <!-- ============================================================ -->
 <section id="part-10" class="scroll-mt-24 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 border-t border-gray-200 dark:border-gray-700">
-    <div class="mb-8 border-l-4 border-blue-500 pl-6">
-        <span class="text-sm font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide">Part 10 of 10</span>
+    <div class="mb-8 border-l-4 border-teal-500 pl-6">
+        <span class="text-sm font-semibold text-teal-600 dark:text-teal-400 uppercase tracking-wide">Part 10 of 10</span>
         <h2 class="text-3xl font-bold text-gray-900 dark:text-white mt-2">The Future of AI-Assisted Development</h2>
         <p class="text-gray-500 dark:text-gray-400 mt-1">7 min read</p>
     </div>
@@ -1391,15 +1391,15 @@ CREATE TABLE users (
             <h2>🚀 What's Next for AI Development?</h2>
             <p>AI tools are evolving at a breathtaking pace. Here's what I see coming:</p>
             <div class="my-6 space-y-6">
-                <div class="rounded-lg bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 p-6 border border-blue-200 dark:border-blue-800">
+                <div class="rounded-lg bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 p-6 border border-teal-200 dark:border-teal-800">
                     <h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">🧠 Smarter Context Understanding</h4>
                     <p class="text-gray-700 dark:text-gray-300">AI will get better at understanding entire codebases, not just individual files. This means fewer context-switching issues and more coherent suggestions.</p>
                 </div>
-                <div class="rounded-lg bg-gradient-to-r from-green-50 to-blue-50 dark:from-green-900/20 dark:to-blue-900/20 p-6 border border-green-200 dark:border-green-800">
+                <div class="rounded-lg bg-gradient-to-r from-green-50 to-teal-50 dark:from-green-900/20 dark:to-teal-900/20 p-6 border border-green-200 dark:border-green-800">
                     <h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">🔗 Better Tool Integration</h4>
                     <p class="text-gray-700 dark:text-gray-300">Expect tighter integration between AI and development tools — from design to deployment, AI will be woven into every step.</p>
                 </div>
-                <div class="rounded-lg bg-gradient-to-r from-blue-50 to-amber-50 dark:from-blue-900/20 dark:to-amber-900/20 p-6 border border-blue-200 dark:border-blue-800">
+                <div class="rounded-lg bg-gradient-to-r from-teal-50 to-amber-50 dark:from-teal-900/20 dark:to-amber-900/20 p-6 border border-teal-200 dark:border-teal-800">
                     <h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">🎯 More Specialized Models</h4>
                     <p class="text-gray-700 dark:text-gray-300">Instead of one-size-fits-all, we'll see AI models specialized for different frameworks, languages, and even types of applications.</p>
                 </div>
@@ -1420,7 +1420,7 @@ CREATE TABLE users (
             <h2>🎓 Parting Advice</h2>
             <div class="my-8 space-y-6">
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold text-sm">1</div>
+                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold text-sm">1</div>
                     <div><h4 class="text-lg font-semibold text-gray-900 dark:text-white">Start Building Today</h4><p class="text-gray-700 dark:text-gray-300">Don't wait for the perfect idea or the perfect moment. The best way to learn is by doing.</p></div>
                 </div>
                 <div class="flex items-start space-x-4">
@@ -1428,11 +1428,11 @@ CREATE TABLE users (
                     <div><h4 class="text-lg font-semibold text-gray-900 dark:text-white">Stay Curious</h4><p class="text-gray-700 dark:text-gray-300">AI tools change fast. Keep experimenting, keep learning, and don't be afraid to try new approaches.</p></div>
                 </div>
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold text-sm">3</div>
+                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold text-sm">3</div>
                     <div><h4 class="text-lg font-semibold text-gray-900 dark:text-white">Build for People</h4><p class="text-gray-700 dark:text-gray-300">Technology is a means to an end. Focus on solving real problems for real people, and the tools will follow.</p></div>
                 </div>
                 <div class="flex items-start space-x-4">
-                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold text-sm">4</div>
+                    <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold text-sm">4</div>
                     <div><h4 class="text-lg font-semibold text-gray-900 dark:text-white">Share Your Journey</h4><p class="text-gray-700 dark:text-gray-300">Document what you learn. Others are on the same path, and your experience might be exactly what someone needs to hear.</p></div>
                 </div>
             </div>
@@ -1446,12 +1446,12 @@ CREATE TABLE users (
 
         <section id="cheat-sheet">
             <h2>📋 AI Development Cheat Sheet</h2>
-            <div class="not-prose my-8 rounded-xl bg-gradient-to-br from-blue-600 via-blue-600 to-blue-600 p-1">
+            <div class="not-prose my-8 rounded-xl bg-gradient-to-br from-teal-600 via-teal-600 to-teal-600 p-1">
                 <div class="rounded-xl bg-white dark:bg-gray-900 p-8">
                     <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 text-center">Quick Reference Guide</h3>
                     <div class="grid md:grid-cols-2 gap-6">
                         <div>
-                            <h4 class="text-lg font-semibold text-blue-600 dark:text-blue-400 mb-3">🚀 Quick Start</h4>
+                            <h4 class="text-lg font-semibold text-teal-600 dark:text-teal-400 mb-3">🚀 Quick Start</h4>
                             <ol class="space-y-1 text-gray-700 dark:text-gray-300 text-sm">
                                 <li>Pick an idea you're passionate about</li>
                                 <li>Use AI to brainstorm and refine it</li>
@@ -1471,7 +1471,7 @@ CREATE TABLE users (
                             </ul>
                         </div>
                         <div>
-                            <h4 class="text-lg font-semibold text-blue-600 dark:text-blue-400 mb-3">⭐ Best Practices</h4>
+                            <h4 class="text-lg font-semibold text-teal-600 dark:text-teal-400 mb-3">⭐ Best Practices</h4>
                             <ul class="space-y-1 text-gray-700 dark:text-gray-300 text-sm">
                                 <li>Be specific in your prompts</li>
                                 <li>Break complex tasks into small steps</li>
@@ -1501,7 +1501,7 @@ CREATE TABLE users (
                             </ul>
                         </div>
                         <div>
-                            <h4 class="text-lg font-semibold text-blue-600 dark:text-blue-400 mb-3">🎯 Closing Thought</h4>
+                            <h4 class="text-lg font-semibold text-teal-600 dark:text-teal-400 mb-3">🎯 Closing Thought</h4>
                             <p class="text-gray-700 dark:text-gray-300 text-sm italic">"AI makes the fast things faster. Your job is to bring the wisdom — the decisions, the empathy, the judgment that turns code into products people love."</p>
                         </div>
                     </div>
@@ -1517,7 +1517,7 @@ CREATE TABLE users (
         <div class="text-4xl mb-4">🎉</div>
         <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">You've Completed the Series!</h2>
         <p class="text-gray-600 dark:text-gray-400 mb-8 max-w-2xl mx-auto">Thank you for reading "How I Built MiniBreaks.io With AI" — all 10 parts. I hope this series has inspired you to start building with AI.</p>
-        <a href="/series" class="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors">
+        <a href="/series" class="inline-flex items-center px-6 py-3 bg-teal-600 text-white font-medium rounded-lg hover:bg-teal-700 transition-colors">
             <i class="fas fa-arrow-left mr-2" aria-hidden="true"></i>
             Back to Series Overview
         </a>

--- a/src/routes/series/part-1-can-you-build-with-ai/+page.svelte
+++ b/src/routes/series/part-1-can-you-build-with-ai/+page.svelte
@@ -26,7 +26,7 @@
 		>
 			Can You Really Build a Website with AI?
 		</h1>
-		<h2 class="mb-8 text-center text-2xl font-medium text-blue-600 md:text-3xl dark:text-blue-400">
+		<h2 class="mb-8 text-center text-2xl font-medium text-teal-600 md:text-3xl dark:text-teal-400">
 			(Spoiler: Yes, But…)
 		</h2>
 
@@ -44,7 +44,7 @@
 			Welcome to my exploration of building <a
 				href="https://minibreaks.io"
 				target="_blank"
-				class="text-blue-600 underline decoration-2 underline-offset-2 transition-colors hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+				class="text-teal-600 underline decoration-2 underline-offset-2 transition-colors hover:text-teal-800 dark:text-teal-400 dark:hover:text-teal-300"
 				>MiniBreaks.io</a
 			> with AI. A story of me trying to build a complete website using artificial intelligence as my
 			development partner.
@@ -65,7 +65,7 @@
 			good sense of what needed to happen—but even for me, the process wasn't exactly plug-and-play.
 		</p>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
 			<p class="mb-0 text-gray-700 dark:text-gray-300">
 				<strong>Here's the thing:</strong> AI is incredibly powerful, but it's not a magic wand. It's
 				more like having a really smart assistant who knows a lot about coding but still needs clear
@@ -190,9 +190,9 @@
 		<div class="my-8 space-y-6">
 			<div class="flex items-start space-x-4">
 				<div
-					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"
+					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"
 				>
-					<i class="fas fa-tools text-blue-600 dark:text-blue-300" aria-hidden="true"></i>
+					<i class="fas fa-tools text-teal-600 dark:text-teal-300" aria-hidden="true"></i>
 				</div>
 				<div>
 					<h4 class="mb-2 font-bold text-gray-900 dark:text-white">
@@ -207,9 +207,9 @@
 
 			<div class="flex items-start space-x-4">
 				<div
-					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"
+					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"
 				>
-					<i class="fas fa-comment-dots text-blue-600 dark:text-blue-300" aria-hidden="true"></i>
+					<i class="fas fa-comment-dots text-teal-600 dark:text-teal-300" aria-hidden="true"></i>
 				</div>
 				<div>
 					<h4 class="mb-2 font-bold text-gray-900 dark:text-white">Writing Effective Prompts</h4>
@@ -237,9 +237,9 @@
 
 			<div class="flex items-start space-x-4">
 				<div
-					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"
+					class="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"
 				>
-					<i class="fas fa-handshake text-blue-600 dark:text-blue-300"></i>
+					<i class="fas fa-handshake text-teal-600 dark:text-teal-300"></i>
 				</div>
 				<div>
 					<h4 class="mb-2 font-bold text-gray-900 dark:text-white">Making AI Your Partner</h4>
@@ -267,13 +267,13 @@
 		</p>
 
 		<div
-			class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20"
+			class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20"
 		>
 			<div class="flex items-start space-x-3">
-				<i class="fas fa-lightbulb mt-1 text-blue-600 dark:text-blue-400"></i>
+				<i class="fas fa-lightbulb mt-1 text-teal-600 dark:text-teal-400"></i>
 				<div>
-					<p class="mb-2 font-semibold text-blue-800 dark:text-blue-300">My Promise to You</p>
-					<p class="mb-0 text-blue-700 dark:text-blue-400">
+					<p class="mb-2 font-semibold text-teal-800 dark:text-teal-300">My Promise to You</p>
+					<p class="mb-0 text-teal-700 dark:text-teal-400">
 						No jargon without explanation. No skipped steps. No "and then magic happens" moments.
 						Just honest, practical guidance from someone who's been through the process.
 					</p>
@@ -300,7 +300,7 @@
 		</p>
 
 		<div
-			class="not-prose my-8 rounded-lg border border-blue-200 bg-gradient-to-r from-blue-50 to-blue-50 p-8 text-center dark:border-blue-700 dark:from-blue-900/20 dark:to-blue-900/20"
+			class="not-prose my-8 rounded-lg border border-teal-200 bg-gradient-to-r from-teal-50 to-teal-50 p-8 text-center dark:border-teal-700 dark:from-teal-900/20 dark:to-teal-900/20"
 		>
 			<h3 class="mb-4 text-2xl font-bold text-gray-900 dark:text-white">
 				Ready to Start Building?

--- a/src/routes/series/part-10-future-ai-development/+page.svelte
+++ b/src/routes/series/part-10-future-ai-development/+page.svelte
@@ -32,7 +32,7 @@
 		>
 			The Future of AI-Assisted Development
 		</h1>
-		<h2 class="mb-8 text-center text-2xl font-medium text-blue-600 md:text-3xl dark:text-blue-400">
+		<h2 class="mb-8 text-center text-2xl font-medium text-teal-600 md:text-3xl dark:text-teal-400">
 			& Your Complete AI Development Cheat Sheet
 		</h2>
 
@@ -91,12 +91,12 @@
 
 			<p>It's like asking a master plumber to suddenly create a fine-dining French cuisine experience — just because there's now a robot that can cook.</p>
 
-			<div class="bg-blue-50 border-l-4 border-blue-500 p-4 my-6 dark:bg-blue-900/20 dark:border-blue-400">
+			<div class="bg-teal-50 border-l-4 border-teal-500 p-4 my-6 dark:bg-teal-900/20 dark:border-teal-400">
 				<div class="flex items-start">
-					<i class="fas fa-lightbulb text-blue-500 mt-1 mr-3 dark:text-blue-400" aria-hidden="true"></i>
+					<i class="fas fa-lightbulb text-teal-500 mt-1 mr-3 dark:text-teal-400" aria-hidden="true"></i>
 					<div>
-						<p class="font-semibold text-blue-800 dark:text-blue-300 mb-2">Key Insight</p>
-						<p class="text-blue-700 dark:text-blue-200 mb-0">AI can empower you. It can save you time. But it still needs you — your judgment, your creativity, your intent. That's why I believe no one, especially those without an engineering background, should be judged by how "vibey" their code feels.</p>
+						<p class="font-semibold text-teal-800 dark:text-teal-300 mb-2">Key Insight</p>
+						<p class="text-teal-700 dark:text-teal-200 mb-0">AI can empower you. It can save you time. But it still needs you — your judgment, your creativity, your intent. That's why I believe no one, especially those without an engineering background, should be judged by how "vibey" their code feels.</p>
 					</div>
 				</div>
 			</div>
@@ -130,17 +130,17 @@
 			<p class="text-lg font-medium text-gray-800 dark:text-gray-200 mb-6">Here's everything you need to know in one compact reference — bookmark this section!</p>
 
 			<!-- Cheat Sheet Container -->
-			<div class="bg-gradient-to-br from-blue-50 to-blue-50 dark:from-gray-800 dark:to-gray-900 rounded-2xl p-6 border border-blue-200 dark:border-gray-700 shadow-lg">
+			<div class="bg-gradient-to-br from-teal-50 to-teal-50 dark:from-gray-800 dark:to-gray-900 rounded-2xl p-6 border border-teal-200 dark:border-gray-700 shadow-lg">
 
 				<!-- Quick Start Section -->
 				<div class="mb-8">
-					<h4 class="text-xl font-bold text-blue-800 dark:text-blue-300 mb-4 flex items-center">
+					<h4 class="text-xl font-bold text-teal-800 dark:text-teal-300 mb-4 flex items-center">
 						🚀 Quick Start
 					</h4>
 					<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
 						<div class="bg-white dark:bg-gray-700 rounded-lg p-4 shadow-sm">
 							<div class="flex items-start">
-								<span class="bg-blue-500 text-white text-sm font-bold rounded-full w-6 h-6 flex items-center justify-center mr-3 mt-0.5">1</span>
+								<span class="bg-teal-500 text-white text-sm font-bold rounded-full w-6 h-6 flex items-center justify-center mr-3 mt-0.5">1</span>
 								<div>
 									<h4 class="font-semibold text-gray-800 dark:text-gray-200">Decide what to build</h4>
 									<p class="text-sm text-gray-600 dark:text-gray-400">Be specific about your goals</p>
@@ -149,7 +149,7 @@
 						</div>
 						<div class="bg-white dark:bg-gray-700 rounded-lg p-4 shadow-sm">
 							<div class="flex items-start">
-								<span class="bg-blue-500 text-white text-sm font-bold rounded-full w-6 h-6 flex items-center justify-center mr-3 mt-0.5">2</span>
+								<span class="bg-teal-500 text-white text-sm font-bold rounded-full w-6 h-6 flex items-center justify-center mr-3 mt-0.5">2</span>
 								<div>
 									<h4 class="font-semibold text-gray-800 dark:text-gray-200">Choose simple tools</h4>
 									<p class="text-sm text-gray-600 dark:text-gray-400">e.g., SvelteKit + Render</p>
@@ -158,7 +158,7 @@
 						</div>
 						<div class="bg-white dark:bg-gray-700 rounded-lg p-4 shadow-sm md:col-span-2">
 							<div class="flex items-start">
-								<span class="bg-blue-500 text-white text-sm font-bold rounded-full w-6 h-6 flex items-center justify-center mr-3 mt-0.5">3</span>
+								<span class="bg-teal-500 text-white text-sm font-bold rounded-full w-6 h-6 flex items-center justify-center mr-3 mt-0.5">3</span>
 								<div>
 									<h4 class="font-semibold text-gray-800 dark:text-gray-200">Use AI as co-pilot, not autopilot</h4>
 									<p class="text-sm text-gray-600 dark:text-gray-400">Stay involved in the process</p>
@@ -178,17 +178,17 @@
 							<div class="p-4 space-y-3">
 								<div class="flex justify-between items-center">
 									<span class="font-semibold text-gray-800 dark:text-gray-200">ChatGPT / Copilot</span>
-									<span class="text-sm bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded">Guidance & Code</span>
+									<span class="text-sm bg-teal-100 dark:bg-teal-900 text-teal-800 dark:text-teal-200 px-2 py-1 rounded">Guidance & Code</span>
 								</div>
 								<div class="flex justify-between items-center">
 									<span class="font-semibold text-gray-800 dark:text-gray-200">VS Code / Cursor</span>
-									<span class="text-sm bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded">Writing & Testing</span>
+									<span class="text-sm bg-teal-100 dark:bg-teal-900 text-teal-800 dark:text-teal-200 px-2 py-1 rounded">Writing & Testing</span>
 								</div>
 							</div>
 							<div class="p-4 space-y-3">
 								<div class="flex justify-between items-center">
 									<span class="font-semibold text-gray-800 dark:text-gray-200">Hugging Face / OpenAI</span>
-									<span class="text-sm bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-1 rounded">AI & Design</span>
+									<span class="text-sm bg-teal-100 dark:bg-teal-900 text-teal-800 dark:text-teal-200 px-2 py-1 rounded">AI & Design</span>
 								</div>
 								<div class="flex justify-between items-center">
 									<span class="font-semibold text-gray-800 dark:text-gray-200">Render / Netlify / Vercel</span>
@@ -203,8 +203,8 @@
 				<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
 					<!-- Best Practices -->
 					<div>
-						<h4 class="text-xl font-bold text-blue-800 dark:text-blue-300 mb-4 flex items-center">
-							<i class="fas fa-comments mr-3 text-blue-600" aria-hidden="true"></i> Best Prompt Practices
+						<h4 class="text-xl font-bold text-teal-800 dark:text-teal-300 mb-4 flex items-center">
+							<i class="fas fa-comments mr-3 text-teal-600" aria-hidden="true"></i> Best Prompt Practices
 						</h4>
 						<div class="bg-white dark:bg-gray-700 rounded-lg p-4 shadow-sm space-y-3">
 							<div class="flex items-center">
@@ -261,8 +261,8 @@
 						<p class="text-gray-700 dark:text-gray-300 font-medium mb-3">✨ Ask AI to:</p>
 						<div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
 							<div class="text-center">
-								<div class="bg-blue-100 dark:bg-blue-900 rounded-lg p-3 mb-2">
-									<i class="fas fa-code-branch text-blue-600 text-xl" aria-hidden="true"></i>
+								<div class="bg-teal-100 dark:bg-teal-900 rounded-lg p-3 mb-2">
+									<i class="fas fa-code-branch text-teal-600 text-xl" aria-hidden="true"></i>
 								</div>
 								<span class="text-sm font-medium text-gray-800 dark:text-gray-200">Review your code</span>
 							</div>
@@ -273,8 +273,8 @@
 								<span class="text-sm font-medium text-gray-800 dark:text-gray-200">Explain concepts</span>
 							</div>
 							<div class="text-center">
-								<div class="bg-blue-100 dark:bg-blue-900 rounded-lg p-3 mb-2">
-									<i class="fas fa-vial text-blue-600 text-xl" aria-hidden="true"></i>
+								<div class="bg-teal-100 dark:bg-teal-900 rounded-lg p-3 mb-2">
+									<i class="fas fa-vial text-teal-600 text-xl" aria-hidden="true"></i>
 								</div>
 								<span class="text-sm font-medium text-gray-800 dark:text-gray-200">Suggest tests</span>
 							</div>
@@ -289,7 +289,7 @@
 				</div>
 
 				<!-- Final Reminder -->
-				<div class="bg-gradient-to-r from-green-50 to-blue-50 dark:from-green-900/30 dark:to-blue-900/30 border-2 border-green-200 dark:border-green-700 rounded-lg p-6 text-center">
+				<div class="bg-gradient-to-r from-green-50 to-teal-50 dark:from-green-900/30 dark:to-teal-900/30 border-2 border-green-200 dark:border-green-700 rounded-lg p-6 text-center">
 					<h4 class="text-xl font-bold mb-3 flex items-center justify-center text-gray-800 dark:text-gray-200">
 						<i class="fas fa-heart mr-3 text-green-600 dark:text-green-400" aria-hidden="true"></i>🌟 Closing Reminder
 					</h4>
@@ -303,7 +303,7 @@
 		</div>
 
 		<!-- Call to Action -->
-		<div class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 rounded-xl p-8 text-center border border-blue-200 dark:border-blue-700 mt-12">
+		<div class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 rounded-xl p-8 text-center border border-teal-200 dark:border-teal-700 mt-12">
 			<h4 class="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-4">Ready to Start Building?</h4>
 			<p class="text-gray-600 dark:text-gray-400 mb-6">
 				Take what you've learned and start your own AI-assisted development journey. Remember, every expert was once a beginner.
@@ -313,7 +313,7 @@
 					<i class="fas fa-arrow-left mr-3 no-underline" style="color: white !important; text-decoration: none !important;" aria-hidden="true"></i>
 					<span style="color: white !important; ">Review the Full Series</span>
 				</a>
-				<a href="https://minibreaks.io" target="_blank" class="inline-flex items-center px-8 py-4 bg-blue-600 hover:bg-blue-700 font-bold rounded-lg transition-colors shadow-lg hover:shadow-xl border border-blue-500 no-underline" style="color: white !important; ">
+				<a href="https://minibreaks.io" target="_blank" class="inline-flex items-center px-8 py-4 bg-teal-600 hover:bg-teal-700 font-bold rounded-lg transition-colors shadow-lg hover:shadow-xl border border-teal-500 no-underline" style="color: white !important; ">
 					<i class="fas fa-external-link-alt mr-3 no-underline" style="color: white !important; text-decoration: none !important;" aria-hidden="true"></i>
 					<span style="color: white !important; ">See MiniBreaks.io Live</span>
 				</a>
@@ -321,14 +321,14 @@
 		</div>
 
 		<!-- Want to Read More? Section -->
-		<div class="bg-gradient-to-r from-blue-50 to-blue-50 dark:from-blue-900/20 dark:to-blue-900/20 rounded-xl p-8 text-center border border-blue-200 dark:border-blue-700 mt-8">
+		<div class="bg-gradient-to-r from-teal-50 to-teal-50 dark:from-teal-900/20 dark:to-teal-900/20 rounded-xl p-8 text-center border border-teal-200 dark:border-teal-700 mt-8">
 			<h4 class="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-4">Want to read more?</h4>
 			<p class="text-gray-600 dark:text-gray-400 mb-6">
 				If you enjoyed this AI development series, you might be interested in my thoughts on the future of how we interact with software.
 			</p>
 			<div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-600 max-w-2xl mx-auto mb-6">
 				<div class="flex items-center justify-center mb-4">
-					<i class="fas fa-th text-blue-500 text-2xl mr-3"></i>
+					<i class="fas fa-th text-teal-500 text-2xl mr-3"></i>
 					<h5 class="text-xl font-bold text-gray-800 dark:text-gray-200">Mosaic: Rethinking App Flows</h5>
 				</div>
 				<p class="text-gray-600 dark:text-gray-400 text-left mb-4">
@@ -338,7 +338,7 @@
 					A 4-part exploration of the future of digital interaction design.
 				</p>
 			</div>
-			<a href="/mosaic" class="inline-flex items-center px-8 py-4 bg-blue-100 dark:bg-blue-600 hover:bg-blue-400 text-white font-bold rounded-lg transition-colors shadow-lg hover:shadow-xl border border-blue-500 no-underline">
+			<a href="/mosaic" class="inline-flex items-center px-8 py-4 bg-teal-100 dark:bg-teal-600 hover:bg-teal-400 text-white font-bold rounded-lg transition-colors shadow-lg hover:shadow-xl border border-teal-500 no-underline">
 				<i class="fas fa-th mr-3" aria-hidden="true"></i>
 				<span>Read the Mosaic Series</span>
 			</a>

--- a/src/routes/series/part-2-why-use-ai/+page.svelte
+++ b/src/routes/series/part-2-why-use-ai/+page.svelte
@@ -29,7 +29,7 @@
 		>
 			Why I Wanted to Use AI
 		</h1>
-		<h2 class="mb-8 text-center text-2xl font-medium text-blue-600 md:text-3xl dark:text-blue-400">
+		<h2 class="mb-8 text-center text-2xl font-medium text-teal-600 md:text-3xl dark:text-teal-400">
 			Setting Realistic Expectations
 		</h2>
 
@@ -180,13 +180,13 @@
 		</p>
 
     <div
-			class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20"
+			class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20"
 		>
 			<div class="flex items-start space-x-3">
-				<i class="fas fa-lightbulb mt-1 text-blue-600 dark:text-blue-400" aria-hidden="true"></i>
+				<i class="fas fa-lightbulb mt-1 text-teal-600 dark:text-teal-400" aria-hidden="true"></i>
 				<div>
-					<p class="mb-2 font-semibold text-blue-800 dark:text-blue-300">Key Lesson</p>
-					<p class="mb-0 text-blue-700 dark:text-blue-400">
+					<p class="mb-2 font-semibold text-teal-800 dark:text-teal-300">Key Lesson</p>
+					<p class="mb-0 text-teal-700 dark:text-teal-400">
 I need to get my requirements right before
       asking AI to implement them.
     					</p>
@@ -207,7 +207,7 @@ I need to get my requirements right before
 
 		<h3 id="reflection-questions">Questions for You</h3>
 
-		<div class="my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+		<div class="my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
 			<ul class="space-y-3">
 				<li>
 					<strong>What do you want AI to do for you?</strong> Be specific. Is it about speed? Learning?

--- a/src/routes/series/part-3-tools-and-setup/+page.svelte
+++ b/src/routes/series/part-3-tools-and-setup/+page.svelte
@@ -75,8 +75,8 @@
 		</p>
 
 		<div class="not-prose my-8 grid grid-cols-1 gap-6 md:grid-cols-2">
-			<div class="rounded-lg border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<h4 class="mb-2 font-bold text-blue-700 dark:text-blue-300">💬 ChatGPT</h4>
+			<div class="rounded-lg border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<h4 class="mb-2 font-bold text-teal-700 dark:text-teal-300">💬 ChatGPT</h4>
 				<p class="text-sm text-gray-600 dark:text-gray-400">
 					Your AI brainstorming partner and problem solver
 				</p>
@@ -87,14 +87,14 @@
 					Your AI coding assistant that writes code as you instruct it
 				</p>
 			</div>
-			<div class="rounded-lg border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<h4 class="mb-2 font-bold text-blue-700 dark:text-blue-300">🤗 Hugging Face</h4>
+			<div class="rounded-lg border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<h4 class="mb-2 font-bold text-teal-700 dark:text-teal-300">🤗 Hugging Face</h4>
 				<p class="text-sm text-gray-600 dark:text-gray-400">
 					Free AI models for advanced features such as designing (optional)
 				</p>
 			</div>
-			<div class="rounded-lg border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<h4 class="mb-2 font-bold text-blue-700 dark:text-blue-300">📁 GitHub</h4>
+			<div class="rounded-lg border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<h4 class="mb-2 font-bold text-teal-700 dark:text-teal-300">📁 GitHub</h4>
 				<p class="text-sm text-gray-600 dark:text-gray-400">
 					Where your code lives and how you deploy your site
 				</p>
@@ -103,7 +103,7 @@
 
 <h3 id="chatgpt">ChatGPT - Your AI Assistant</h3>
 
-<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-4 dark:bg-blue-900/20">
+<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-4 dark:bg-teal-900/20">
   <p class="mb-0 text-gray-700 dark:text-gray-300">
     <strong>Think of ChatGPT as your patient mentor who never gets tired of explaining things.</strong>
   </p>
@@ -168,7 +168,7 @@
       However, after using both tools extensively, I found that GitHub Copilot had gained noticeable improvements in its suggestions and accuracy.
     </p>
 
-		<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-4 dark:bg-blue-900/20">
+		<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-4 dark:bg-teal-900/20">
 			<p class="mb-0 text-gray-700 dark:text-gray-300">
 				<strong>My recommendation:</strong> Start with Cursor (free), do as much as you can in the first 2 weeks, and add GitHub Copilot later if
 				you want even more AI assistance.
@@ -270,9 +270,9 @@
 			<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
 				<div class="text-center">
 					<div
-						class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"
+						class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"
 					>
-						<span class="font-bold text-blue-600 dark:text-blue-300">1</span>
+						<span class="font-bold text-teal-600 dark:text-teal-300">1</span>
 					</div>
 					<h4 class="mb-1 font-bold text-gray-900 dark:text-white">Plan with ChatGPT</h4>
 					<p class="text-sm text-gray-600 dark:text-gray-400">Brainstorm and plan your feature</p>
@@ -288,9 +288,9 @@
 				</div>
 				<div class="text-center">
 					<div
-						class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900"
+						class="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900"
 					>
-						<span class="font-bold text-blue-600 dark:text-blue-300">3</span>
+						<span class="font-bold text-teal-600 dark:text-teal-300">3</span>
 					</div>
 					<h4 class="mb-1 font-bold text-gray-900 dark:text-white">Deploy to GitHub</h4>
 					<p class="text-sm text-gray-600 dark:text-gray-400">Push your changes live</p>
@@ -306,23 +306,23 @@
 
 		<div class="my-6 space-y-4">
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Create your GitHub account and first repository</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Download and install Visual Studio Code</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Sign up for GitHub Copilot (start your free trial)</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Sign up for ChatGPT (free account is fine)</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Install Git to connect your computer to GitHub (ask ChatGPT if not familiar)</span>
 			</div>
 		</div>

--- a/src/routes/series/part-4-crafting-idea-mvp/+page.svelte
+++ b/src/routes/series/part-4-crafting-idea-mvp/+page.svelte
@@ -110,7 +110,7 @@
 
 		<div class="not-prose my-8 space-y-6">
 			<div class="flex items-start space-x-4">
-				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					1
 				</div>
 				<div>
@@ -140,7 +140,7 @@
 			</div>
 
 			<div class="flex items-start space-x-4">
-				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					3
 				</div>
 				<div>
@@ -170,7 +170,7 @@
 			Why? Because you can define the tone and role AI should play for you. For example:
 		</p>
 
-		<div class="not-prose my-6 rounded-lg bg-blue-50 p-6 dark:bg-blue-900/20">
+		<div class="not-prose my-6 rounded-lg bg-teal-50 p-6 dark:bg-teal-900/20">
 			<p class="mb-0 text-gray-700 dark:text-gray-300">
 				<strong>Project Instructions:</strong><br>
 				"I'd like you to act as my co-founder and brainstorming partner. Please focus on creative yet
@@ -285,23 +285,23 @@
 
 		<div class="my-6 space-y-4">
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Set up a ChatGPT Project for your website brainstorming (if using paid version)</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Write down 3 different website ideas you're considering</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>For each idea, brainstorm with AI using the 3 guidelines</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Choose ONE idea and write your MVP in exactly one paragraph</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Cross-reference your MVP with a second AI tool</span>
 			</div>
 		</div>
@@ -319,7 +319,7 @@
 			</ul>
 		</div>
 
-		<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-4 dark:bg-blue-900/20">
+		<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-4 dark:bg-teal-900/20">
 			<p class="mb-0 text-gray-700 dark:text-gray-300">
 				<strong>📝 Example MVP:</strong> "MiniBreaks.io is a playful website encourages taking mindful breaks, promotes workplace well-being, and fosters a sense of fun through achievements and leaderboards."
 			</p>
@@ -346,7 +346,7 @@
 			speaks to your users' needs.
 		</p>
 
-		<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-4 dark:bg-blue-900/20">
+		<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-4 dark:bg-teal-900/20">
 			<p class="mb-0 text-gray-700 dark:text-gray-300">
 				<strong>🎨 Coming up:</strong> We'll explore AI-powered design tools, learn prompt engineering
 				for visual concepts, and create a design system that you can actually implement.

--- a/src/routes/series/part-5-designing-ui-ux/+page.svelte
+++ b/src/routes/series/part-5-designing-ui-ux/+page.svelte
@@ -65,11 +65,11 @@
 			This is completely free, but with very limited number of uses. But if you get your prompt right, you should get what you want with one or two attempts.
 		</p>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-			<p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+			<p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">
 				Keep in mind:
 			</p>
-			<p class="mb-0 text-blue-700 dark:text-blue-300">
+			<p class="mb-0 text-teal-700 dark:text-teal-300">
 				This HuggingFace workspace does not build a complete website. Instead, it generates a beautifully designed landing page (homepage) to serve as the foundation of your site's design system. The expectation is creating the design system of your website, and then you can use other AI tools to expand from there.
 			</p>
 		</div>
@@ -159,7 +159,7 @@
 
 		<div class="not-prose my-6 space-y-4">
 			<div class="flex items-start space-x-4">
-				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					1
 				</div>
 				<div>
@@ -196,20 +196,20 @@
 
 		<div class="my-6 space-y-4">
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Visit the DeepSite workspace and generate a homepage for your own idea</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Iterate on your prompt if needed - remember, you have limited attempts, so make them count!</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Once happy with the result, click View Source, copy all the code, and save it as <code>generated.html</code></span>
 			</div>
 		</div>
 
-		<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-4 dark:bg-blue-900/20">
+		<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-4 dark:bg-teal-900/20">
 			<p class="mb-0 text-gray-700 dark:text-gray-300">
 				💡 <strong>Pro tip:</strong> Be as specific as possible in your prompt about the mood, target audience, and key features you want to highlight.
 			</p>

--- a/src/routes/series/part-6-writing-code-ai/+page.svelte
+++ b/src/routes/series/part-6-writing-code-ai/+page.svelte
@@ -70,11 +70,11 @@
 			In the previous part, you used DeepSite to create your first landing page, which already included TailwindCSS and some vanilla JavaScript.
 		</p>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-			<p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+			<p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">
 				Why not just stick with vanilla JavaScript?
 			</p>
-			<p class="mb-0 text-blue-700 dark:text-blue-300">
+			<p class="mb-0 text-teal-700 dark:text-teal-300">
 				Vanilla JavaScript (i.e., plain JavaScript without a framework) works great for adding simple user interactions, animations, and maintaining user state in the browser. However, as your website grows, it becomes hard to maintain and scale.
 			</p>
 		</div>
@@ -158,11 +158,11 @@
 				</div>
 			</div>
 
-			<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">
+			<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">
 					💡 Personal Experience
 				</p>
-				<p class="mb-0 text-blue-700 dark:text-blue-300">
+				<p class="mb-0 text-teal-700 dark:text-teal-300">
 					When I first tried using AI to generate React code, I often had to fix mismatched libraries or deprecated APIs. With SvelteKit, I had a much smoother experience — and I could focus on building rather than debugging.
 				</p>
 			</div>
@@ -241,9 +241,9 @@
 			In Cursor (or with GitHub Copilot in VS Code), activate Agent mode and include <code>generated.html</code> in the context. Then use this prompt:
 		</p>
 
-		<div class="not-prose my-6 rounded-lg bg-gray-100 p-6 dark:bg-gray-800 border-l-4 border-blue-500">
+		<div class="not-prose my-6 rounded-lg bg-gray-100 p-6 dark:bg-gray-800 border-l-4 border-teal-500">
 			<div class="mb-3 flex items-center">
-				<i class="fas fa-robot mr-2 text-blue-600 dark:text-blue-400" aria-hidden="true"></i>
+				<i class="fas fa-robot mr-2 text-teal-600 dark:text-teal-400" aria-hidden="true"></i>
 				<span class="font-semibold text-gray-900 dark:text-white">AI Prompt Template</span>
 			</div>
 			<div class="text-sm text-gray-700 dark:text-gray-300 font-mono bg-white dark:bg-gray-900 p-4 rounded border">
@@ -269,11 +269,11 @@
 						<li>All JavaScript converted to TypeScript</li>
 					</ul>
 
-					<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-						<p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">
+					<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+						<p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">
 							✨ The Magic Moment
 						</p>
-						<p class="mb-0 text-blue-700 dark:text-blue-300">
+						<p class="mb-0 text-teal-700 dark:text-teal-300">
 							You now have a structured, maintainable project with a home page, an about page, and reusable components — making it easy for AI (and you) to expand further.
 						</p>
 					</div>
@@ -310,7 +310,7 @@
 		<div class="my-8 space-y-6">
 			<div class="rounded-lg border border-gray-200 p-6 dark:border-gray-700 dark:bg-gray-800">
 				<h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white">
-					<i class="fas fa-code mr-3 text-blue-500" aria-hidden="true"></i>
+					<i class="fas fa-code mr-3 text-teal-500" aria-hidden="true"></i>
 					Be Specific with Context
 				</h4>
 				<p class="text-gray-700 dark:text-gray-300">
@@ -330,7 +330,7 @@
 
 			<div class="rounded-lg border border-gray-200 p-6 dark:border-gray-700 dark:bg-gray-800">
 				<h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white">
-					<i class="fas fa-sync-alt mr-3 text-blue-500" aria-hidden="true"></i>
+					<i class="fas fa-sync-alt mr-3 text-teal-500" aria-hidden="true"></i>
 					Iterate and Refine
 				</h4>
 				<p class="text-gray-700 dark:text-gray-300">
@@ -354,34 +354,34 @@
 
 		<div class="my-6 space-y-4">
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Install <a href="https://nodejs.org/en/download" target="_blank">Node.js</a> and
           <a href="https://git-scm.com/downloads" target="_blank">Git</a>
            on your computer</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Create a SvelteKit project using the CLI</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Move your generated.html into the project folder</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Use the AI prompt above to convert your page to SvelteKit</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Open your project in a browser (<code>npm run dev</code>) and explore the result!</span>
 			</div>
 		</div>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-			<p class="mb-2 text-lg font-semibold text-blue-700 dark:text-blue-300">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+			<p class="mb-2 text-lg font-semibold text-teal-700 dark:text-teal-300">
 				🎯 Success Criteria
 			</p>
-			<p class="mb-0 text-blue-700 dark:text-blue-300">
+			<p class="mb-0 text-teal-700 dark:text-teal-300">
 				By the end of this exercise, you should have a working SvelteKit application that you can view in your browser, with your design properly componentized and at least two pages (Home and About).
 			</p>
 		</div>
@@ -403,7 +403,7 @@
 			<li>Step-by-step instructions for wiring these features to your UI</li>
 		</ul>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
 			<p class="mb-0 text-gray-700 dark:text-gray-300">
 				<strong>🔧 Coming up:</strong> We'll explore how AI can help you implement complex features like user accounts, email systems, and databases with practical examples and real code you can use in your project.
 			</p>

--- a/src/routes/series/part-7-adding-advanced-features/+page.svelte
+++ b/src/routes/series/part-7-adding-advanced-features/+page.svelte
@@ -66,11 +66,11 @@
 			<li><strong>Adding password recovery</strong> - Using an email API for user support</li>
 		</ul>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-			<p class="mb-2 font-medium text-blue-800 dark:text-blue-200">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+			<p class="mb-2 font-medium text-teal-800 dark:text-teal-200">
 				<i class="fas fa-lightbulb mr-2" aria-hidden="true"></i>Remember Our Approach
 			</p>
-			<p class="text-blue-700 dark:text-blue-300">
+			<p class="text-teal-700 dark:text-teal-300">
 				We'll continue using AI assistance throughout this process. The key is breaking down complex features into clear, manageable steps that AI can help us implement effectively.
 			</p>
 		</div>
@@ -85,7 +85,7 @@
 
 		<div class="not-prose my-6 space-y-4">
 			<div class="flex items-start space-x-4">
-				<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					<i class="fas fa-table" aria-hidden="true"></i>
 				</div>
 				<div>
@@ -109,7 +109,7 @@
 			</div>
 
 			<div class="flex items-start space-x-4">
-				<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					<i class="fas fa-grip-lines-vertical" aria-hidden="true"></i>
 				</div>
 				<div>
@@ -135,12 +135,12 @@
 
 		<div class="not-prose my-6 space-y-4">
 			<div class="flex items-start space-x-4">
-				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					1
 				</div>
 				<div>
 					<p class="text-gray-700 dark:text-gray-300">
-						Go to <a href="https://www.postgresql.org/download/" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 underline">PostgreSQL Download</a> and choose your operating system.
+						Go to <a href="https://www.postgresql.org/download/" target="_blank" rel="noopener" class="text-teal-600 dark:text-teal-400 underline">PostgreSQL Download</a> and choose your operating system.
 					</p>
 				</div>
 			</div>
@@ -157,7 +157,7 @@
 			</div>
 
 			<div class="flex items-start space-x-4">
-				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					3
 				</div>
 				<div>
@@ -168,7 +168,7 @@
 			</div>
 
 			<div class="flex items-start space-x-4">
-				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					4
 				</div>
 				<div>
@@ -209,10 +209,10 @@
 
 		<div class="not-prose my-8 rounded-lg bg-gray-100 p-6 dark:bg-gray-800">
 			<div class="mb-4 flex items-center">
-				<i class="fas fa-robot mr-3 text-blue-500 text-2xl" aria-hidden="true"></i>
+				<i class="fas fa-robot mr-3 text-teal-500 text-2xl" aria-hidden="true"></i>
 				<h4 class="text-lg font-semibold text-gray-900 dark:text-white">Example Prompt (for non-engineers):</h4>
 			</div>
-			<div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-blue-500">
+			<div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-teal-500">
 				<p class="text-gray-700 dark:text-gray-300 italic">
 					"Create SQL commands to set up a table named 'users'. Each user needs:
 				</p>
@@ -280,10 +280,10 @@ CREATE TABLE users (
 
 		<div class="not-prose my-8 rounded-lg bg-gray-100 p-6 dark:bg-gray-800">
 			<div class="mb-4 flex items-center">
-				<i class="fas fa-sign-in-alt mr-3 text-blue-500 text-2xl" aria-hidden="true"></i>
+				<i class="fas fa-sign-in-alt mr-3 text-teal-500 text-2xl" aria-hidden="true"></i>
 				<h4 class="text-lg font-semibold text-gray-900 dark:text-white">Prompt Example:</h4>
 			</div>
-			<div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-blue-500">
+			<div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-teal-500">
 				<p class="text-gray-700 dark:text-gray-300 italic">
 					"Create a basic login page where users can enter their username and password to log in to their account. Include a 'Remember me' checkbox and a link to password recovery."
 				</p>
@@ -294,21 +294,21 @@ CREATE TABLE users (
 
 		<div class="not-prose my-8 rounded-lg bg-gray-100 p-6 dark:bg-gray-800">
 			<div class="mb-4 flex items-center">
-				<i class="fas fa-key mr-3 text-blue-500 text-2xl" aria-hidden="true"></i>
+				<i class="fas fa-key mr-3 text-teal-500 text-2xl" aria-hidden="true"></i>
 				<h4 class="text-lg font-semibold text-gray-900 dark:text-white">Prompt Example:</h4>
 			</div>
-			<div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-blue-500">
+			<div class="bg-white dark:bg-gray-900 p-4 rounded border-l-4 border-teal-500">
 				<p class="text-gray-700 dark:text-gray-300 italic">
 					"Create a page that lets users recover their password by entering their email. For now, just create the form and logic, but leave the email sending functionality as a placeholder that I can complete later."
 				</p>
 			</div>
 		</div>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-			<p class="mb-2 font-medium text-blue-800 dark:text-blue-200">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+			<p class="mb-2 font-medium text-teal-800 dark:text-teal-200">
 				<i class="fas fa-lightbulb mr-2" aria-hidden="true"></i>Why Break It Down?
 			</p>
-			<p class="text-blue-700 dark:text-blue-300">
+			<p class="text-teal-700 dark:text-teal-300">
 				By splitting authentication into separate prompts, you get cleaner, more focused code. AI can concentrate on one task at a time, resulting in better quality and easier debugging.
 			</p>
 		</div>
@@ -325,12 +325,12 @@ CREATE TABLE users (
 
 		<div class="not-prose my-6 space-y-4">
 			<div class="flex items-start space-x-4">
-				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					1
 				</div>
 				<div>
 					<p class="text-gray-700 dark:text-gray-300">
-						Visit <a href="https://developers.brevo.com/docs/send-a-transactional-email" target="_blank" rel="noopener" class="text-blue-600 dark:text-blue-400 underline">Brevo API documentation</a>.
+						Visit <a href="https://developers.brevo.com/docs/send-a-transactional-email" target="_blank" rel="noopener" class="text-teal-600 dark:text-teal-400 underline">Brevo API documentation</a>.
 					</p>
 				</div>
 			</div>
@@ -347,7 +347,7 @@ CREATE TABLE users (
 			</div>
 
 			<div class="flex items-start space-x-4">
-				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white font-bold">
+				<div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-teal-500 text-white font-bold">
 					3
 				</div>
 				<div>
@@ -421,7 +421,7 @@ CREATE TABLE users (
 
 			<div class="rounded-lg border border-gray-200 p-6 dark:border-gray-700 dark:bg-gray-800">
 				<h4 class="mb-3 flex items-center text-lg font-semibold text-gray-900 dark:text-white">
-					<i class="fas fa-shield-alt mr-3 text-blue-500" aria-hidden="true"></i>
+					<i class="fas fa-shield-alt mr-3 text-teal-500" aria-hidden="true"></i>
 					API Key Security
 				</h4>
 				<ul class="space-y-2 text-gray-700 dark:text-gray-300">
@@ -457,36 +457,36 @@ CREATE TABLE users (
 
 		<div class="my-6 space-y-4">
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Install PostgreSQL, create your database, and user table using the SQL commands generated by AI</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Generate your signup and login pages using clear AI prompts</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Create the password recovery page without the email-sending logic</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Sign up for Brevo, obtain your API key, and store it securely</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Use AI to connect email sending functionality to your password recovery</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span>Document your prompts and AI outputs clearly to track your progress!</span>
 			</div>
 		</div>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-			<p class="mb-2 font-medium text-blue-800 dark:text-blue-200">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+			<p class="mb-2 font-medium text-teal-800 dark:text-teal-200">
 				<i class="fas fa-lightbulb mr-2" aria-hidden="true"></i>Documentation Tip
 			</p>
-			<p class="text-blue-700 dark:text-blue-300">
+			<p class="text-teal-700 dark:text-teal-300">
 				Keep a simple text file or document where you record the prompts you used and what AI generated. This becomes invaluable when you need to make changes or debug issues later. It's like having a conversation history with your AI assistant!
 			</p>
 		</div>
@@ -508,7 +508,7 @@ CREATE TABLE users (
 			<li>Different deployment environments and strategies</li>
 		</ul>
 
-		<div class="not-prose my-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
+		<div class="not-prose my-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
 			<p class="mb-0 text-gray-700 dark:text-gray-300">
 				<strong>🚀 Coming up:</strong> We'll explore how to ensure your website is ready for real users, including performance considerations, security checks, and deployment best practices that will make your launch smooth and successful.
 			</p>

--- a/src/routes/series/part-8-before-deployment/+page.svelte
+++ b/src/routes/series/part-8-before-deployment/+page.svelte
@@ -104,14 +104,14 @@
 			When something doesn't behave correctly, AI can be your debugging partner. Here's a systematic approach:
 		</p>
 
-		<div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6 my-6">
-			<h4 class="text-lg font-semibold text-blue-800 dark:text-blue-200 mb-3">
+		<div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-800 rounded-lg p-6 my-6">
+			<h4 class="text-lg font-semibold text-teal-800 dark:text-teal-200 mb-3">
 				<i class="fas fa-lightbulb mr-2" aria-hidden="true"></i>AI Debugging Prompt Template
 			</h4>
-			<p class="text-blue-700 dark:text-blue-300 mb-3">
+			<p class="text-teal-700 dark:text-teal-300 mb-3">
 				"This [page/feature] isn't working as expected. Here's what I'm seeing: [describe the issue clearly]. Can you help me write a console log to identify the issue?"
 			</p>
-			<p class="text-sm text-blue-600 dark:text-blue-400">
+			<p class="text-sm text-teal-600 dark:text-teal-400">
 				💡 Pro tip: Capture screenshots of browser console logs and share them with AI for more accurate assistance.
 			</p>
 		</div>
@@ -232,11 +232,11 @@
 
     <p>In the above screenshot, you can toggle the responsiveness testing by clicking the button pointed by the red arrow, and you can also change your device size with the dropdown once it's toggled.</p>
 
-		<div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6 my-6">
-			<h4 class="text-lg font-semibold text-blue-800 dark:text-blue-200 mb-3">
+		<div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-800 rounded-lg p-6 my-6">
+			<h4 class="text-lg font-semibold text-teal-800 dark:text-teal-200 mb-3">
 				<i class="fas fa-robot mr-2" aria-hidden="true"></i>AI Accessibility Prompt
 			</h4>
-			<p class="text-blue-700 dark:text-blue-300">
+			<p class="text-teal-700 dark:text-teal-300">
 				"Can you create a simple checklist to ensure my website is accessible and responsive? Focus on the most important items for a beginner."
 			</p>
 		</div>
@@ -283,11 +283,11 @@
 			<li><strong>Minification:</strong> Remove unnecessary characters from code</li>
 		</ul>
 
-		<div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6 my-6">
-			<h4 class="text-lg font-semibold text-blue-800 dark:text-blue-200 mb-3">
+		<div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-800 rounded-lg p-6 my-6">
+			<h4 class="text-lg font-semibold text-teal-800 dark:text-teal-200 mb-3">
 				<i class="fas fa-robot mr-2" aria-hidden="true"></i>AI Performance Prompt
 			</h4>
-			<p class="text-blue-700 dark:text-blue-300">
+			<p class="text-teal-700 dark:text-teal-300">
 				"Can you review my solution and identify possible improvements for performance? Focus on the biggest impact optimizations for a [your technology stack] website."
 			</p>
 		</div>
@@ -376,20 +376,20 @@
 			<li>✅ Error handling implemented for edge cases</li>
 		</ul>
 
-		<div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6 my-6">
-			<h4 class="text-lg font-semibold text-blue-800 dark:text-blue-200 mb-3">
+		<div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-800 rounded-lg p-6 my-6">
+			<h4 class="text-lg font-semibold text-teal-800 dark:text-teal-200 mb-3">
 				<i class="fas fa-rocket mr-2" aria-hidden="true"></i>For SvelteKit Users
 			</h4>
-			<p class="text-blue-700 dark:text-blue-300 mb-3">
+			<p class="text-teal-700 dark:text-teal-300 mb-3">
 				SvelteKit supports multiple deployment methods (serverless, static, node). Check the <a href="https://kit.svelte.dev/docs/adapters" target="_blank" rel="noopener noreferrer" class="underline">adapter documentation</a> for your chosen platform.
 			</p>
 		</div>
 
-		<div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6 my-6">
-			<h4 class="text-lg font-semibold text-blue-800 dark:text-blue-200 mb-3">
+		<div class="bg-teal-50 dark:bg-teal-900/20 border border-teal-200 dark:border-teal-800 rounded-lg p-6 my-6">
+			<h4 class="text-lg font-semibold text-teal-800 dark:text-teal-200 mb-3">
 				<i class="fas fa-robot mr-2" aria-hidden="true"></i>AI Deployment Prompt
 			</h4>
-			<p class="text-blue-700 dark:text-blue-300">
+			<p class="text-teal-700 dark:text-teal-300">
 				"Guide me step-by-step on how to deploy my [technology stack] app using [chosen hosting platform]. Include any specific configuration needed for my setup."
 			</p>
 		</div>
@@ -404,27 +404,27 @@
 
 		<div class="my-6 space-y-4">
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>Manual Testing:</strong> Perform thorough manual testing locally (run <code>npm run dev</code>) to verify all functionality works as expected.</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>Security Implementation:</strong> Apply at least two recommended security practices using AI guidance. Focus on input validation and environment variable protection.</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>Accessibility Audit:</strong> Use the Accessibility Insights extension to perform a quick accessibility audit and fix any critical issues found.</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>Performance Optimization:</strong> Run Lighthouse to boost your website's performance score above 80. Implement suggested improvements.</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>SEO Enhancement:</strong> Implement basic SEO improvements including proper meta tags, alt text for images, and keyword optimization.</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>Deployment Preparation:</strong> Ask AI for detailed deployment guidance on your selected platform and successfully deploy your MVP.</span>
 			</div>
 		</div>

--- a/src/routes/series/part-9-lessons-learned/+page.svelte
+++ b/src/routes/series/part-9-lessons-learned/+page.svelte
@@ -30,7 +30,7 @@
 		>
 			Lessons Learned
 		</h1>
-		<h2 class="mb-8 text-center text-2xl font-medium text-blue-600 md:text-3xl dark:text-blue-400">
+		<h2 class="mb-8 text-center text-2xl font-medium text-teal-600 md:text-3xl dark:text-teal-400">
 			Failures, Frustrations, and Surprises of Building with AI
 		</h2>
 
@@ -48,7 +48,7 @@
 			In this part of the series, I want to share what I learned from building <a
 				href="https://minibreaks.io"
 				target="_blank"
-				class="text-blue-600 underline decoration-2 underline-offset-2 transition-colors hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+				class="text-teal-600 underline decoration-2 underline-offset-2 transition-colors hover:text-teal-800 dark:text-teal-400 dark:hover:text-teal-300"
 				>MiniBreaks.io</a
 			> with AI — including the failures, frustrations, limitations, and surprises. These lessons are for everyone: whether you have a technical background or not, working with AI can feel like having a talented but slightly scatterbrained teammate.
 		</p>
@@ -111,7 +111,7 @@
 		</p>
 
 		<section id="repetitive-suggestions">
-			<h3><i class="fas fa-sync-alt mr-3 text-blue-500" aria-hidden="true"></i>Repetitive Suggestions</h3>
+			<h3><i class="fas fa-sync-alt mr-3 text-teal-500" aria-hidden="true"></i>Repetitive Suggestions</h3>
 
 			<p>
 				One of the most frustrating patterns was when AI got stuck suggesting the same solution over and over — even after I clearly said it didn't work. This happened when debugging CSS layout glitches and while resolving deployment issues.
@@ -121,45 +121,45 @@
 				AI sometimes struggles to "let go" of its initial assumptions, creating an endless loop of unhelpful suggestions.
 			</p>
 
-			<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<h4 class="mb-3 flex items-center text-lg font-semibold text-blue-800 dark:text-blue-200">
+			<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<h4 class="mb-3 flex items-center text-lg font-semibold text-teal-800 dark:text-teal-200">
 					<i class="fas fa-lightbulb mr-3" aria-hidden="true"></i>What I'd do differently
 				</h4>
-				<p class="text-blue-700 dark:text-blue-300">
+				<p class="text-teal-700 dark:text-teal-300">
 					When I notice repeated advice, I now stop sooner, summarize what has already been tried, and explicitly tell AI what to avoid suggesting. That helps break the loop.
 				</p>
 			</div>
 		</section>
 
 		<section id="overcomplicated-code">
-			<h3><i class="fas fa-code mr-3 text-blue-500" aria-hidden="true"></i>Overcomplicated Code</h3>
+			<h3><i class="fas fa-code mr-3 text-teal-500" aria-hidden="true"></i>Overcomplicated Code</h3>
 
 			<p>
 				Another limitation: AI often writes more code than necessary. For example, when I asked for a simple Svelte component, it returned a bloated implementation that added unnecessary dependencies.
 			</p>
 
-			<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<h4 class="mb-3 flex items-center text-lg font-semibold text-blue-800 dark:text-blue-200">
+			<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<h4 class="mb-3 flex items-center text-lg font-semibold text-teal-800 dark:text-teal-200">
 					<i class="fas fa-lightbulb mr-3" aria-hidden="true"></i>What I'd do differently
 				</h4>
-				<p class="text-blue-700 dark:text-blue-300">
+				<p class="text-teal-700 dark:text-teal-300">
 					I now ask AI upfront to "keep it minimal and use only vanilla features unless strictly necessary."
 				</p>
 			</div>
 		</section>
 
 		<section id="wrong-assumptions">
-			<h3><i class="fas fa-exclamation-triangle mr-3 text-blue-500" aria-hidden="true"></i>Wrong Assumptions About Environment</h3>
+			<h3><i class="fas fa-exclamation-triangle mr-3 text-teal-500" aria-hidden="true"></i>Wrong Assumptions About Environment</h3>
 
 			<p>
 				At one point, AI assumed I was running my server on Ubuntu when I was actually on a managed hosting platform. Its advice — such as editing <code>/etc/nginx/sites-available</code> — simply didn't apply.
 			</p>
 
-			<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<h4 class="mb-3 flex items-center text-lg font-semibold text-blue-800 dark:text-blue-200">
+			<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<h4 class="mb-3 flex items-center text-lg font-semibold text-teal-800 dark:text-teal-200">
 					<i class="fas fa-lightbulb mr-3" aria-hidden="true"></i>Lesson learned
 				</h4>
-				<p class="text-blue-700 dark:text-blue-300">
+				<p class="text-teal-700 dark:text-teal-300">
 					Always tell AI your environment and constraints at the beginning. The more context it has, the better it can tailor its advice.
 				</p>
 			</div>
@@ -196,11 +196,11 @@
 				</ol>
 			</div>
 
-			<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<h4 class="mb-3 flex items-center text-lg font-semibold text-blue-800 dark:text-blue-200">
+			<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<h4 class="mb-3 flex items-center text-lg font-semibold text-teal-800 dark:text-teal-200">
 					<i class="fas fa-graduation-cap mr-3" aria-hidden="true"></i>Lesson learned
 				</h4>
-				<p class="text-blue-700 dark:text-blue-300">
+				<p class="text-teal-700 dark:text-teal-300">
 					The clearer your guidance — and the more concrete examples you can give — the better the result.
 				</p>
 			</div>
@@ -235,11 +235,11 @@
 <p>See how happy AI was after she learned about the new error message and understood the root cause?</p>
 <img src="/ai-series/AI-finally-understood-the-issue.jpg" loading="lazy" alt="AI happy after learning about the new error message" class="my-6 w-full rounded-lg shadow-lg">
 
-			<div class="not-prose my-6 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-				<h4 class="mb-3 flex items-center text-lg font-semibold text-blue-800 dark:text-blue-200">
+			<div class="not-prose my-6 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+				<h4 class="mb-3 flex items-center text-lg font-semibold text-teal-800 dark:text-teal-200">
 					<i class="fas fa-graduation-cap mr-3" aria-hidden="true"></i>Lesson learned
 				</h4>
-				<p class="text-blue-700 dark:text-blue-300">
+				<p class="text-teal-700 dark:text-teal-300">
 					Sometimes you need to dig a little yourself to provide AI with the right clue. Without the right context, it can get stuck in a loop.
 				</p>
 			</div>
@@ -254,20 +254,20 @@
 		</p>
 
 		<div class="my-8 grid gap-6 md:grid-cols-2">
-			<div class="rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-800 dark:bg-blue-900/20">
-				<h4 class="mb-4 flex items-center text-lg font-semibold text-blue-800 dark:text-blue-200">
+			<div class="rounded-lg border border-teal-200 bg-teal-50 p-6 dark:border-teal-800 dark:bg-teal-900/20">
+				<h4 class="mb-4 flex items-center text-lg font-semibold text-teal-800 dark:text-teal-200">
 					<i class="fas fa-brain mr-3" aria-hidden="true"></i>It Sometimes Thinks Ahead
 				</h4>
-				<p class="text-blue-700 dark:text-blue-300">
+				<p class="text-teal-700 dark:text-teal-300">
 					One pleasant surprise was how AI occasionally caught things I didn't even think of — like adding <code>aria-*</code> attributes for accessibility or suggesting SEO-friendly meta tags. Those small touches improved the final product.
 				</p>
 			</div>
 
-			<div class="rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-800 dark:bg-blue-900/20">
-				<h4 class="mb-4 flex items-center text-lg font-semibold text-blue-800 dark:text-blue-200">
+			<div class="rounded-lg border border-teal-200 bg-teal-50 p-6 dark:border-teal-800 dark:bg-teal-900/20">
+				<h4 class="mb-4 flex items-center text-lg font-semibold text-teal-800 dark:text-teal-200">
 					<i class="fas fa-magic mr-3" aria-hidden="true"></i>Creative Naming and Messaging
 				</h4>
-				<p class="text-blue-700 dark:text-blue-300">
+				<p class="text-teal-700 dark:text-teal-300">
 					Another surprise was how creative AI can be with wording and tone. When I asked it to help craft playful messages for the mini-games, it delivered delightful, catchy copy that I wouldn't have thought of myself.
 				</p>
 			</div>
@@ -285,26 +285,26 @@
 			AI needs direction, context, and occasionally, a firm correction. The key is learning how to work <em>with</em> it rather than expecting it to work <em>for</em> you.
 		</p>
 
-		<div class="not-prose my-8 rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-800 dark:bg-blue-900/20">
-			<h4 class="mb-4 text-lg font-semibold text-blue-800 dark:text-blue-200">
+		<div class="not-prose my-8 rounded-lg border border-teal-200 bg-teal-50 p-6 dark:border-teal-800 dark:bg-teal-900/20">
+			<h4 class="mb-4 text-lg font-semibold text-teal-800 dark:text-teal-200">
 				If I did this all over again, I'd:
 			</h4>
 			<ul class="space-y-3">
 				<li class="flex items-start">
 					<i class="fas fa-check-circle mt-1 mr-3 text-green-500" aria-hidden="true"></i>
-					<span class="text-blue-700 dark:text-blue-300">Provide more detailed context up front</span>
+					<span class="text-teal-700 dark:text-teal-300">Provide more detailed context up front</span>
 				</li>
 				<li class="flex items-start">
 					<i class="fas fa-check-circle mt-1 mr-3 text-green-500" aria-hidden="true"></i>
-					<span class="text-blue-700 dark:text-blue-300">Set constraints clearly</span>
+					<span class="text-teal-700 dark:text-teal-300">Set constraints clearly</span>
 				</li>
 				<li class="flex items-start">
 					<i class="fas fa-check-circle mt-1 mr-3 text-green-500" aria-hidden="true"></i>
-					<span class="text-blue-700 dark:text-blue-300">Use examples early and often</span>
+					<span class="text-teal-700 dark:text-teal-300">Use examples early and often</span>
 				</li>
 				<li class="flex items-start">
 					<i class="fas fa-check-circle mt-1 mr-3 text-green-500" aria-hidden="true"></i>
-					<span class="text-blue-700 dark:text-blue-300">Trust my own instincts more when something feels wrong</span>
+					<span class="text-teal-700 dark:text-teal-300">Trust my own instincts more when something feels wrong</span>
 				</li>
 			</ul>
 		</div>
@@ -319,21 +319,21 @@
 
 		<div class="my-6 space-y-4">
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>Practice specificity:</strong> Think of one problem you faced recently — technical or not. Write down the exact question you'd ask AI to help with, being as specific as possible.</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>Compare approaches:</strong> Try giving AI a vague version of the question and then a specific version. Compare the results.</span>
 			</div>
 			<div class="flex items-start space-x-3">
-				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-blue-600" disabled />
+				<input type="checkbox" class="mt-1 h-5 w-5 rounded text-teal-600" disabled />
 				<span><strong>Plan your context:</strong> Write down three pieces of context you'd include next time you ask AI for help.</span>
 			</div>
 		</div>
 
-		<div class="not-prose mt-8 border-l-4 border-blue-500 bg-blue-50 p-6 dark:bg-blue-900/20">
-			<p class="text-blue-700 dark:text-blue-300">
+		<div class="not-prose mt-8 border-l-4 border-teal-500 bg-teal-50 p-6 dark:bg-teal-900/20">
+			<p class="text-teal-700 dark:text-teal-300">
 				<strong>💡 Tip:</strong> Feel free to share your examples with the community! The more we practice being specific and providing good context, the better our results with AI will be.
 			</p>
 		</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ export default {
 			fontFamily: {
 				'sans': ['Inter', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'sans-serif'],
 				'serif': ['Fraunces', 'Georgia', 'Times New Roman', 'serif'],
+				'mono': ['JetBrains Mono', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'Consolas', 'monospace'],
 			},
 			animation: {
 				'fade-in': 'fadeIn 1s ease-out forwards',


### PR DESCRIPTION
- New graphite + teal left-rail navigation (desktop fixed sidebar, mobile slide-in drawer) replacing the top nav

- Rail organized into EXPLORE / SERIES & TOOLS / LATEST groups; LATEST surfaces the 3 most recent blog posts

- Added /blog writing archive page with JSON-LD Blog schema

- Condensed home page (tighter section spacing, trimmed Writing grid, new Free AI Workflow Review banner)

- Added --on-accent CSS token to fix WCAG contrast failure (white text on dark-mode teal accent was 1.86:1)

- Rail is height-responsive: footer (CTA + socials + theme toggle) always visible; LATEST group hides on short viewports instead of scrolling

- Brand identity tags redesigned as a 2-column chip grid instead of a wrapping dot-separated line